### PR TITLE
feat: implement log, sync, and json stdlib modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,9 @@ add_library(bishop_lib
     stdlib/time.cpp
     stdlib/math.cpp
     stdlib/random.cpp
+    stdlib/log.cpp
+    stdlib/sync.cpp
+    stdlib/json.cpp
 )
 target_link_libraries(bishop_lib fmt::fmt tomlplusplus::tomlplusplus)
 target_include_directories(bishop_lib PUBLIC ${llhttp_SOURCE_DIR}/include)
@@ -167,6 +170,15 @@ add_custom_target(bishop_runtime_headers ALL
     COMMAND ${CMAKE_COMMAND} -E copy
         ${CMAKE_SOURCE_DIR}/runtime/random/random.hpp
         ${CMAKE_BINARY_DIR}/include/bishop/random.hpp
+    COMMAND ${CMAKE_COMMAND} -E copy
+        ${CMAKE_SOURCE_DIR}/runtime/log/log.hpp
+        ${CMAKE_BINARY_DIR}/include/bishop/log.hpp
+    COMMAND ${CMAKE_COMMAND} -E copy
+        ${CMAKE_SOURCE_DIR}/runtime/sync/sync.hpp
+        ${CMAKE_BINARY_DIR}/include/bishop/sync.hpp
+    COMMAND ${CMAKE_COMMAND} -E copy
+        ${CMAKE_SOURCE_DIR}/runtime/json/json.hpp
+        ${CMAKE_BINARY_DIR}/include/bishop/json.hpp
     COMMAND ${CMAKE_COMMAND} -E copy
         ${CMAKE_SOURCE_DIR}/runtime/fiber_asio/round_robin.hpp
         ${CMAKE_BINARY_DIR}/include/bishop/fiber_asio/round_robin.hpp

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,8 @@ install: build
 	@cp $(BUILD_DIR)/include/bishop/time.hpp ~/.local/include/bishop/
 	@cp $(BUILD_DIR)/include/bishop/math.hpp ~/.local/include/bishop/
 	@cp $(BUILD_DIR)/include/bishop/random.hpp ~/.local/include/bishop/
+	@cp $(BUILD_DIR)/include/bishop/log.hpp ~/.local/include/bishop/
+	@cp $(BUILD_DIR)/include/bishop/sync.hpp ~/.local/include/bishop/
 	@cp $(BUILD_DIR)/include/bishop/fiber_asio/*.hpp ~/.local/include/bishop/fiber_asio/
 	@cp $(BUILD_DIR)/include/llhttp.h ~/.local/include/
 	@echo "Installed bishop to ~/.local/bin/"

--- a/codegen/codegen.cpp
+++ b/codegen/codegen.cpp
@@ -64,6 +64,9 @@
 #include "stdlib/time.hpp"
 #include "stdlib/math.hpp"
 #include "stdlib/random.hpp"
+#include "stdlib/sync.hpp"
+#include "stdlib/json.hpp"
+#include "stdlib/log.hpp"
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 
@@ -158,6 +161,27 @@ static bool has_random_import(const map<string, const Module*>& imports) {
 }
 
 /**
+ * Checks if the program imports the log module.
+ */
+static bool has_log_import(const map<string, const Module*>& imports) {
+    return imports.find("log") != imports.end();
+}
+
+/**
+ * Checks if the program imports the sync module.
+ */
+static bool has_sync_import(const map<string, const Module*>& imports) {
+    return imports.find("sync") != imports.end();
+}
+
+/**
+ * Checks if the program imports the json module.
+ */
+static bool has_json_import(const map<string, const Module*>& imports) {
+    return imports.find("json") != imports.end();
+}
+
+/**
  * Checks if the program uses channels (requires boost fiber).
  */
 static bool uses_channels(const Program& program) {
@@ -210,6 +234,18 @@ string generate_module_namespace(CodeGenState& state, const string& name, const 
 
     if (name == "random") {
         return nog::stdlib::generate_random_runtime();
+    }
+
+    if (name == "sync") {
+        return nog::stdlib::generate_sync_runtime();
+    }
+
+    if (name == "json") {
+        return nog::stdlib::generate_json_runtime();
+    }
+
+    if (name == "log") {
+        return nog::stdlib::generate_log_runtime();
     }
 
     string out = "namespace " + name + " {\n\n";
@@ -346,6 +382,18 @@ string generate_with_imports(
 
     if (has_random_import(imports)) {
         out += "#include <bishop/random.hpp>\n";
+    }
+
+    if (has_log_import(imports)) {
+        out += "#include <bishop/log.hpp>\n";
+    }
+
+    if (has_sync_import(imports)) {
+        out += "#include <bishop/sync.hpp>\n";
+    }
+
+    if (has_json_import(imports)) {
+        out += "#include <bishop/json.hpp>\n";
     }
 
     if (uses_channels(*program)) {

--- a/codegen/emit_function_call.cpp
+++ b/codegen/emit_function_call.cpp
@@ -73,6 +73,8 @@ string emit_function_call(CodeGenState& state, const FunctionCall& call) {
             module_name = "bishop_time";
         } else if (module_name == "random") {
             module_name = "bishop_random";
+        } else if (module_name == "sync") {
+            module_name = "bsync";
         }
 
         func_name = module_name + "::" + fn_name;
@@ -89,6 +91,8 @@ string emit_function_call(CodeGenState& state, const FunctionCall& call) {
                 module_name = "bishop_time";
             } else if (module_name == "random") {
                 module_name = "bishop_random";
+            } else if (module_name == "sync") {
+                module_name = "bsync";
             }
 
             func_name = module_name + "::" + fn_name;

--- a/project/module.cpp
+++ b/project/module.cpp
@@ -18,6 +18,9 @@
 #include "stdlib/time.hpp"
 #include "stdlib/math.hpp"
 #include "stdlib/random.hpp"
+#include "stdlib/log.hpp"
+#include "stdlib/sync.hpp"
+#include "stdlib/json.hpp"
 #include <fstream>
 #include <sstream>
 
@@ -190,6 +193,12 @@ unique_ptr<Module> ModuleManager::create_builtin_module(const string& name) {
         mod->ast = nog::stdlib::create_math_module();
     } else if (name == "random") {
         mod->ast = nog::stdlib::create_random_module();
+    } else if (name == "log") {
+        mod->ast = nog::stdlib::create_log_module();
+    } else if (name == "sync") {
+        mod->ast = nog::stdlib::create_sync_module();
+    } else if (name == "json") {
+        mod->ast = nog::stdlib::create_json_module();
     } else {
         return nullptr;
     }

--- a/runtime/json/json.hpp
+++ b/runtime/json/json.hpp
@@ -1,0 +1,706 @@
+/**
+ * @file json.hpp
+ * @brief Bishop JSON runtime library.
+ *
+ * Provides JSON parsing and serialization for Bishop programs.
+ * This header is included when programs import the json module.
+ *
+ * Uses a simple recursive descent parser for JSON.
+ * JSON values are represented using std::variant.
+ */
+
+#pragma once
+
+#include <bishop/std.hpp>
+#include <string>
+#include <vector>
+#include <map>
+#include <variant>
+#include <sstream>
+#include <stdexcept>
+#include <cctype>
+#include <cstdlib>
+#include <iomanip>
+#include <memory>
+
+namespace bishop {
+
+/**
+ * Simple Result type for fallible operations in json module.
+ * Holds either a value of type T or an error.
+ * Uses optional<T> for the value and shared_ptr<Error> for errors
+ * to be compatible with the code generator.
+ */
+struct JsonError {
+    std::string message;
+    JsonError(const std::string& msg) : message(msg) {}
+};
+
+template<typename T>
+class Result {
+private:
+    std::optional<T> val_;
+    std::shared_ptr<JsonError> err_;
+
+public:
+    Result() : val_(std::nullopt), err_(nullptr) {}
+    Result(T v) : val_(std::move(v)), err_(nullptr) {}
+    Result(std::shared_ptr<JsonError> e) : val_(std::nullopt), err_(std::move(e)) {}
+
+    static Result<T> ok(T v) {
+        return Result<T>(std::move(v));
+    }
+
+    static Result<T> err(const std::string& msg) {
+        return Result<T>(std::make_shared<JsonError>(msg));
+    }
+
+    static Result<T> err(std::shared_ptr<JsonError> e) {
+        return Result<T>(std::move(e));
+    }
+
+    bool is_ok() const { return val_.has_value(); }
+    bool is_error() const { return !is_ok(); }
+
+    T& value() { return *val_; }
+    const T& value() const { return *val_; }
+
+    std::shared_ptr<JsonError> error() const { return err_; }
+
+    explicit operator bool() const { return is_ok(); }
+};
+
+}  // namespace bishop
+
+namespace json {
+
+// Forward declaration
+class Json;
+
+// JSON value types
+using JsonNull = std::monostate;
+using JsonBool = bool;
+using JsonInt = int64_t;
+using JsonFloat = double;
+using JsonString = std::string;
+using JsonArray = std::vector<std::shared_ptr<Json>>;
+using JsonObject = std::map<std::string, std::shared_ptr<Json>>;
+
+using JsonValue = std::variant<JsonNull, JsonBool, JsonInt, JsonFloat, JsonString, JsonArray, JsonObject>;
+
+/**
+ * JSON value class.
+ * Wraps a variant holding all possible JSON types.
+ */
+class Json {
+public:
+    JsonValue value;
+
+    Json() : value(JsonNull{}) {}
+    explicit Json(JsonNull) : value(JsonNull{}) {}
+    explicit Json(bool b) : value(b) {}
+    explicit Json(int64_t i) : value(i) {}
+    explicit Json(int i) : value(static_cast<int64_t>(i)) {}
+    explicit Json(long long i) : value(static_cast<int64_t>(i)) {}
+    explicit Json(double d) : value(d) {}
+    explicit Json(const std::string& s) : value(s) {}
+    explicit Json(std::string&& s) : value(std::move(s)) {}
+    explicit Json(const char* s) : value(std::string(s)) {}
+    explicit Json(JsonArray arr) : value(std::move(arr)) {}
+    explicit Json(JsonObject obj) : value(std::move(obj)) {}
+
+    // Type checking methods
+    bool is_null() const { return std::holds_alternative<JsonNull>(value); }
+    bool is_bool() const { return std::holds_alternative<JsonBool>(value); }
+    bool is_int() const { return std::holds_alternative<JsonInt>(value); }
+    bool is_float() const { return std::holds_alternative<JsonFloat>(value); }
+    bool is_str() const { return std::holds_alternative<JsonString>(value); }
+    bool is_list() const { return std::holds_alternative<JsonArray>(value); }
+    bool is_object() const { return std::holds_alternative<JsonObject>(value); }
+
+    // Value extraction with error handling
+    bishop::Result<std::string> as_str() const {
+        if (!is_str()) {
+            return bishop::Result<std::string>::err("TypeError: expected string");
+        }
+        return bishop::Result<std::string>::ok(std::get<JsonString>(value));
+    }
+
+    bishop::Result<int64_t> as_int() const {
+        if (is_int()) {
+            return bishop::Result<int64_t>::ok(std::get<JsonInt>(value));
+        }
+        if (is_float()) {
+            return bishop::Result<int64_t>::ok(static_cast<int64_t>(std::get<JsonFloat>(value)));
+        }
+        return bishop::Result<int64_t>::err("TypeError: expected integer");
+    }
+
+    bishop::Result<double> as_float() const {
+        if (is_float()) {
+            return bishop::Result<double>::ok(std::get<JsonFloat>(value));
+        }
+        if (is_int()) {
+            return bishop::Result<double>::ok(static_cast<double>(std::get<JsonInt>(value)));
+        }
+        return bishop::Result<double>::err("TypeError: expected float");
+    }
+
+    bishop::Result<bool> as_bool() const {
+        if (!is_bool()) {
+            return bishop::Result<bool>::err("TypeError: expected boolean");
+        }
+        return bishop::Result<bool>::ok(std::get<JsonBool>(value));
+    }
+
+    // Get by key (for objects) or index (for arrays)
+    bishop::Result<Json> get(const std::string& key) const {
+        if (is_object()) {
+            const auto& obj = std::get<JsonObject>(value);
+            auto it = obj.find(key);
+            if (it == obj.end()) {
+                return bishop::Result<Json>::err("KeyError: key not found: " + key);
+            }
+            return bishop::Result<Json>::ok(*it->second);
+        }
+        if (is_list()) {
+            // Try to parse key as index
+            try {
+                size_t idx = std::stoull(key);
+                const auto& arr = std::get<JsonArray>(value);
+                if (idx >= arr.size()) {
+                    return bishop::Result<Json>::err("IndexError: index out of bounds: " + key);
+                }
+                return bishop::Result<Json>::ok(*arr[idx]);
+            } catch (...) {
+                return bishop::Result<Json>::err("TypeError: array index must be an integer");
+            }
+        }
+        return bishop::Result<Json>::err("TypeError: cannot index into non-object/non-array");
+    }
+
+    // Typed getters
+    bishop::Result<std::string> get_str(const std::string& key) const {
+        auto result = get(key);
+        if (!result.is_ok()) return bishop::Result<std::string>::err(result.error());
+        return result.value().as_str();
+    }
+
+    bishop::Result<int64_t> get_int(const std::string& key) const {
+        auto result = get(key);
+        if (!result.is_ok()) return bishop::Result<int64_t>::err(result.error());
+        return result.value().as_int();
+    }
+
+    bishop::Result<double> get_float(const std::string& key) const {
+        auto result = get(key);
+        if (!result.is_ok()) return bishop::Result<double>::err(result.error());
+        return result.value().as_float();
+    }
+
+    bishop::Result<bool> get_bool(const std::string& key) const {
+        auto result = get(key);
+        if (!result.is_ok()) return bishop::Result<bool>::err(result.error());
+        return result.value().as_bool();
+    }
+
+    bishop::Result<Json> get_list(const std::string& key) const {
+        auto result = get(key);
+        if (!result.is_ok()) return result;
+        if (!result.value().is_list()) {
+            return bishop::Result<Json>::err("TypeError: expected array");
+        }
+        return result;
+    }
+
+    bishop::Result<Json> get_object(const std::string& key) const {
+        auto result = get(key);
+        if (!result.is_ok()) return result;
+        if (!result.value().is_object()) {
+            return bishop::Result<Json>::err("TypeError: expected object");
+        }
+        return result;
+    }
+
+    // Path access with dot notation
+    bishop::Result<Json> path(const std::string& path_str) const {
+        Json current = *this;
+        std::string segment;
+        std::istringstream stream(path_str);
+
+        while (std::getline(stream, segment, '.')) {
+            if (segment.empty()) continue;
+            auto result = current.get(segment);
+            if (!result.is_ok()) return result;
+            current = result.value();
+        }
+
+        return bishop::Result<Json>::ok(current);
+    }
+
+    // Setters for objects
+    void set(const std::string& key, const Json& val) {
+        if (!is_object()) return;
+        auto& obj = std::get<JsonObject>(value);
+        obj[key] = std::make_shared<Json>(val);
+    }
+
+    void set_str(const std::string& key, const std::string& val) {
+        set(key, Json(val));
+    }
+
+    void set_int(const std::string& key, int64_t val) {
+        set(key, Json(val));
+    }
+
+    void set_float(const std::string& key, double val) {
+        set(key, Json(val));
+    }
+
+    void set_bool(const std::string& key, bool val) {
+        set(key, Json(val));
+    }
+
+    void set_null(const std::string& key) {
+        set(key, Json(JsonNull{}));
+    }
+
+    // Push for arrays
+    void push(const Json& val) {
+        if (!is_list()) return;
+        auto& arr = std::get<JsonArray>(value);
+        arr.push_back(std::make_shared<Json>(val));
+    }
+
+    void push_str(const std::string& val) {
+        push(Json(val));
+    }
+
+    void push_int(int64_t val) {
+        push(Json(val));
+    }
+
+    void push_float(double val) {
+        push(Json(val));
+    }
+
+    void push_bool(bool val) {
+        push(Json(val));
+    }
+
+    void push_null() {
+        push(Json(JsonNull{}));
+    }
+
+    // Utility methods
+    int64_t length() const {
+        if (is_list()) {
+            return static_cast<int64_t>(std::get<JsonArray>(value).size());
+        }
+        if (is_object()) {
+            return static_cast<int64_t>(std::get<JsonObject>(value).size());
+        }
+        return 0;
+    }
+
+    std::string keys() const {
+        if (!is_object()) return "";
+        std::string result;
+        const auto& obj = std::get<JsonObject>(value);
+        for (const auto& [key, _] : obj) {
+            if (!result.empty()) result += "\n";
+            result += key;
+        }
+        return result;
+    }
+
+    bool has(const std::string& key) const {
+        if (!is_object()) return false;
+        const auto& obj = std::get<JsonObject>(value);
+        return obj.find(key) != obj.end();
+    }
+
+    void remove(const std::string& key) {
+        if (!is_object()) return;
+        auto& obj = std::get<JsonObject>(value);
+        obj.erase(key);
+    }
+};
+
+// JSON Parser
+class JsonParser {
+public:
+    explicit JsonParser(const std::string& input) : input_(input), pos_(0) {}
+
+    bishop::Result<Json> parse() {
+        skip_whitespace();
+        if (pos_ >= input_.size()) {
+            return bishop::Result<Json>::err("ParseError: empty input");
+        }
+        auto result = parse_value();
+        if (!result.is_ok()) return result;
+        skip_whitespace();
+        if (pos_ < input_.size()) {
+            return bishop::Result<Json>::err("ParseError: unexpected characters after JSON");
+        }
+        return result;
+    }
+
+private:
+    const std::string& input_;
+    size_t pos_;
+
+    char peek() const {
+        return pos_ < input_.size() ? input_[pos_] : '\0';
+    }
+
+    char consume() {
+        return pos_ < input_.size() ? input_[pos_++] : '\0';
+    }
+
+    void skip_whitespace() {
+        while (pos_ < input_.size() && std::isspace(static_cast<unsigned char>(input_[pos_]))) {
+            ++pos_;
+        }
+    }
+
+    bishop::Result<Json> parse_value() {
+        skip_whitespace();
+        char c = peek();
+
+        if (c == '"') return parse_string();
+        if (c == '{') return parse_object();
+        if (c == '[') return parse_array();
+        if (c == 't' || c == 'f') return parse_bool();
+        if (c == 'n') return parse_null();
+        if (c == '-' || std::isdigit(static_cast<unsigned char>(c))) return parse_number();
+
+        return bishop::Result<Json>::err("ParseError: unexpected character: " + std::string(1, c));
+    }
+
+    bishop::Result<Json> parse_string() {
+        if (consume() != '"') {
+            return bishop::Result<Json>::err("ParseError: expected '\"'");
+        }
+
+        std::string result;
+        while (pos_ < input_.size() && peek() != '"') {
+            char c = consume();
+            if (c == '\\') {
+                if (pos_ >= input_.size()) {
+                    return bishop::Result<Json>::err("ParseError: unexpected end of string");
+                }
+                char escaped = consume();
+                switch (escaped) {
+                    case '"': result += '"'; break;
+                    case '\\': result += '\\'; break;
+                    case '/': result += '/'; break;
+                    case 'b': result += '\b'; break;
+                    case 'f': result += '\f'; break;
+                    case 'n': result += '\n'; break;
+                    case 'r': result += '\r'; break;
+                    case 't': result += '\t'; break;
+                    case 'u': {
+                        // Unicode escape: \uXXXX
+                        if (pos_ + 4 > input_.size()) {
+                            return bishop::Result<Json>::err("ParseError: invalid unicode escape");
+                        }
+                        std::string hex = input_.substr(pos_, 4);
+                        pos_ += 4;
+                        try {
+                            unsigned int codepoint = std::stoul(hex, nullptr, 16);
+                            if (codepoint < 0x80) {
+                                result += static_cast<char>(codepoint);
+                            } else if (codepoint < 0x800) {
+                                result += static_cast<char>(0xC0 | (codepoint >> 6));
+                                result += static_cast<char>(0x80 | (codepoint & 0x3F));
+                            } else {
+                                result += static_cast<char>(0xE0 | (codepoint >> 12));
+                                result += static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F));
+                                result += static_cast<char>(0x80 | (codepoint & 0x3F));
+                            }
+                        } catch (...) {
+                            return bishop::Result<Json>::err("ParseError: invalid unicode escape");
+                        }
+                        break;
+                    }
+                    default:
+                        return bishop::Result<Json>::err("ParseError: invalid escape sequence");
+                }
+            } else {
+                result += c;
+            }
+        }
+
+        if (consume() != '"') {
+            return bishop::Result<Json>::err("ParseError: unterminated string");
+        }
+
+        return bishop::Result<Json>::ok(Json(result));
+    }
+
+    bishop::Result<Json> parse_number() {
+        size_t start = pos_;
+        bool is_float = false;
+
+        if (peek() == '-') consume();
+
+        if (peek() == '0') {
+            consume();
+        } else if (std::isdigit(static_cast<unsigned char>(peek()))) {
+            while (std::isdigit(static_cast<unsigned char>(peek()))) consume();
+        } else {
+            return bishop::Result<Json>::err("ParseError: invalid number");
+        }
+
+        if (peek() == '.') {
+            is_float = true;
+            consume();
+            if (!std::isdigit(static_cast<unsigned char>(peek()))) {
+                return bishop::Result<Json>::err("ParseError: invalid number");
+            }
+            while (std::isdigit(static_cast<unsigned char>(peek()))) consume();
+        }
+
+        if (peek() == 'e' || peek() == 'E') {
+            is_float = true;
+            consume();
+            if (peek() == '+' || peek() == '-') consume();
+            if (!std::isdigit(static_cast<unsigned char>(peek()))) {
+                return bishop::Result<Json>::err("ParseError: invalid number");
+            }
+            while (std::isdigit(static_cast<unsigned char>(peek()))) consume();
+        }
+
+        std::string num_str = input_.substr(start, pos_ - start);
+        try {
+            if (is_float) {
+                return bishop::Result<Json>::ok(Json(std::stod(num_str)));
+            } else {
+                return bishop::Result<Json>::ok(Json(std::stoll(num_str)));
+            }
+        } catch (...) {
+            return bishop::Result<Json>::err("ParseError: invalid number: " + num_str);
+        }
+    }
+
+    bishop::Result<Json> parse_bool() {
+        if (input_.substr(pos_, 4) == "true") {
+            pos_ += 4;
+            return bishop::Result<Json>::ok(Json(true));
+        }
+        if (input_.substr(pos_, 5) == "false") {
+            pos_ += 5;
+            return bishop::Result<Json>::ok(Json(false));
+        }
+        return bishop::Result<Json>::err("ParseError: expected 'true' or 'false'");
+    }
+
+    bishop::Result<Json> parse_null() {
+        if (input_.substr(pos_, 4) == "null") {
+            pos_ += 4;
+            return bishop::Result<Json>::ok(Json(JsonNull{}));
+        }
+        return bishop::Result<Json>::err("ParseError: expected 'null'");
+    }
+
+    bishop::Result<Json> parse_array() {
+        if (consume() != '[') {
+            return bishop::Result<Json>::err("ParseError: expected '['");
+        }
+
+        JsonArray arr;
+        skip_whitespace();
+
+        if (peek() == ']') {
+            consume();
+            return bishop::Result<Json>::ok(Json(std::move(arr)));
+        }
+
+        while (true) {
+            auto elem = parse_value();
+            if (!elem.is_ok()) return elem;
+            arr.push_back(std::make_shared<Json>(elem.value()));
+
+            skip_whitespace();
+            if (peek() == ']') {
+                consume();
+                break;
+            }
+            if (peek() != ',') {
+                return bishop::Result<Json>::err("ParseError: expected ',' or ']'");
+            }
+            consume();
+        }
+
+        return bishop::Result<Json>::ok(Json(std::move(arr)));
+    }
+
+    bishop::Result<Json> parse_object() {
+        if (consume() != '{') {
+            return bishop::Result<Json>::err("ParseError: expected '{'");
+        }
+
+        JsonObject obj;
+        skip_whitespace();
+
+        if (peek() == '}') {
+            consume();
+            return bishop::Result<Json>::ok(Json(std::move(obj)));
+        }
+
+        while (true) {
+            skip_whitespace();
+            if (peek() != '"') {
+                return bishop::Result<Json>::err("ParseError: expected string key");
+            }
+
+            auto key_result = parse_string();
+            if (!key_result.is_ok()) return key_result;
+            std::string key = std::get<JsonString>(key_result.value().value);
+
+            skip_whitespace();
+            if (consume() != ':') {
+                return bishop::Result<Json>::err("ParseError: expected ':'");
+            }
+
+            auto val = parse_value();
+            if (!val.is_ok()) return val;
+            obj[key] = std::make_shared<Json>(val.value());
+
+            skip_whitespace();
+            if (peek() == '}') {
+                consume();
+                break;
+            }
+            if (peek() != ',') {
+                return bishop::Result<Json>::err("ParseError: expected ',' or '}'");
+            }
+            consume();
+        }
+
+        return bishop::Result<Json>::ok(Json(std::move(obj)));
+    }
+};
+
+// Stringify functions
+inline std::string escape_string(const std::string& s) {
+    std::string result;
+    result.reserve(s.size() + 2);
+    result += '"';
+    for (char c : s) {
+        switch (c) {
+            case '"': result += "\\\""; break;
+            case '\\': result += "\\\\"; break;
+            case '\b': result += "\\b"; break;
+            case '\f': result += "\\f"; break;
+            case '\n': result += "\\n"; break;
+            case '\r': result += "\\r"; break;
+            case '\t': result += "\\t"; break;
+            default:
+                if (static_cast<unsigned char>(c) < 0x20) {
+                    std::ostringstream oss;
+                    oss << "\\u" << std::hex << std::setfill('0') << std::setw(4)
+                        << static_cast<int>(static_cast<unsigned char>(c));
+                    result += oss.str();
+                } else {
+                    result += c;
+                }
+        }
+    }
+    result += '"';
+    return result;
+}
+
+inline std::string stringify_impl(const Json& j, bool pretty, int indent_level);
+
+inline std::string stringify_value(const JsonValue& v, bool pretty, int indent_level) {
+    return std::visit([pretty, indent_level](const auto& val) -> std::string {
+        using T = std::decay_t<decltype(val)>;
+        if constexpr (std::is_same_v<T, JsonNull>) {
+            return "null";
+        } else if constexpr (std::is_same_v<T, JsonBool>) {
+            return val ? "true" : "false";
+        } else if constexpr (std::is_same_v<T, JsonInt>) {
+            return std::to_string(val);
+        } else if constexpr (std::is_same_v<T, JsonFloat>) {
+            std::ostringstream oss;
+            oss << std::setprecision(17) << val;
+            std::string s = oss.str();
+            // Ensure it looks like a float
+            if (s.find('.') == std::string::npos && s.find('e') == std::string::npos) {
+                s += ".0";
+            }
+            return s;
+        } else if constexpr (std::is_same_v<T, JsonString>) {
+            return escape_string(val);
+        } else if constexpr (std::is_same_v<T, JsonArray>) {
+            if (val.empty()) return "[]";
+            std::string result = "[";
+            std::string indent(indent_level * 2, ' ');
+            std::string inner_indent((indent_level + 1) * 2, ' ');
+            for (size_t i = 0; i < val.size(); ++i) {
+                if (pretty) {
+                    result += "\n" + inner_indent;
+                }
+                result += stringify_impl(*val[i], pretty, indent_level + 1);
+                if (i + 1 < val.size()) result += ",";
+            }
+            if (pretty) {
+                result += "\n" + indent;
+            }
+            result += "]";
+            return result;
+        } else if constexpr (std::is_same_v<T, JsonObject>) {
+            if (val.empty()) return "{}";
+            std::string result = "{";
+            std::string indent(indent_level * 2, ' ');
+            std::string inner_indent((indent_level + 1) * 2, ' ');
+            size_t i = 0;
+            for (const auto& [key, value] : val) {
+                if (pretty) {
+                    result += "\n" + inner_indent;
+                }
+                result += escape_string(key);
+                result += pretty ? ": " : ":";
+                result += stringify_impl(*value, pretty, indent_level + 1);
+                if (i + 1 < val.size()) result += ",";
+                ++i;
+            }
+            if (pretty) {
+                result += "\n" + indent;
+            }
+            result += "}";
+            return result;
+        }
+        return "null";
+    }, v);
+}
+
+inline std::string stringify_impl(const Json& j, bool pretty, int indent_level) {
+    return stringify_value(j.value, pretty, indent_level);
+}
+
+// Public API functions
+inline bishop::Result<Json> parse(const std::string& text) {
+    JsonParser parser(text);
+    return parser.parse();
+}
+
+inline Json object() {
+    return Json(JsonObject{});
+}
+
+inline Json array() {
+    return Json(JsonArray{});
+}
+
+inline std::string stringify(const Json& value) {
+    return stringify_impl(value, false, 0);
+}
+
+inline std::string stringify_pretty(const Json& value) {
+    return stringify_impl(value, true, 0);
+}
+
+}  // namespace json

--- a/runtime/log/log.hpp
+++ b/runtime/log/log.hpp
@@ -1,0 +1,308 @@
+/**
+ * @file log.hpp
+ * @brief Bishop logging runtime library.
+ *
+ * Provides logging operations for Bishop programs.
+ * This header is included when programs import the log module.
+ *
+ * Features:
+ * - Thread-safe logging with mutex protection
+ * - Multiple log levels (DEBUG, INFO, WARN, ERROR)
+ * - Configurable output format
+ * - Console and file output support
+ * - Per-file log level filtering
+ */
+
+#pragma once
+
+#include <bishop/std.hpp>
+#include <fstream>
+#include <sstream>
+#include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <vector>
+#include <memory>
+
+namespace log {
+
+// Log level constants
+constexpr int DEBUG = 0;
+constexpr int INFO = 1;
+constexpr int WARN = 2;
+constexpr int ERROR = 3;
+
+/**
+ * Internal logging state.
+ * Uses thread-safe access patterns.
+ */
+struct LogState {
+    std::mutex mutex;
+    int current_level = INFO;
+    std::string format_string = "[%Y-%m-%d %H:%M:%S] [%l] %v";
+
+    struct FileOutput {
+        std::unique_ptr<std::ofstream> file;
+        int min_level;
+    };
+    std::vector<FileOutput> file_outputs;
+};
+
+/**
+ * Gets the global logging state.
+ */
+inline LogState& get_state() {
+    static LogState state;
+    return state;
+}
+
+/**
+ * Thread-safe wrapper for localtime.
+ */
+inline std::tm safe_localtime(std::time_t time) {
+    std::tm result = {};
+#if defined(_WIN32) || defined(_WIN64)
+    localtime_s(&result, &time);
+#else
+    localtime_r(&time, &result);
+#endif
+    return result;
+}
+
+/**
+ * Converts log level to string representation.
+ */
+inline std::string level_to_string(int level) {
+    switch (level) {
+        case DEBUG: return "DEBUG";
+        case INFO:  return "INFO";
+        case WARN:  return "WARN";
+        case ERROR: return "ERROR";
+        default:    return "UNKNOWN";
+    }
+}
+
+/**
+ * Formats a log message according to the current format string.
+ *
+ * Supported format specifiers:
+ * - %Y, %m, %d, %H, %M, %S - strftime specifiers for timestamp
+ * - %l - log level name
+ * - %v - the log message
+ */
+inline std::string format_message(int level, const std::string& message, const std::string& format) {
+    auto now = std::chrono::system_clock::now();
+    auto time_t_val = std::chrono::system_clock::to_time_t(now);
+    std::tm tm_val = safe_localtime(time_t_val);
+
+    std::string result;
+    result.reserve(format.size() + message.size() + 32);
+
+    for (size_t i = 0; i < format.size(); ++i) {
+        if (format[i] == '%' && i + 1 < format.size()) {
+            char spec = format[i + 1];
+            ++i;
+
+            switch (spec) {
+                case 'Y': {
+                    result += std::to_string(tm_val.tm_year + 1900);
+                    break;
+                }
+                case 'm': {
+                    if (tm_val.tm_mon + 1 < 10) result += '0';
+                    result += std::to_string(tm_val.tm_mon + 1);
+                    break;
+                }
+                case 'd': {
+                    if (tm_val.tm_mday < 10) result += '0';
+                    result += std::to_string(tm_val.tm_mday);
+                    break;
+                }
+                case 'H': {
+                    if (tm_val.tm_hour < 10) result += '0';
+                    result += std::to_string(tm_val.tm_hour);
+                    break;
+                }
+                case 'M': {
+                    if (tm_val.tm_min < 10) result += '0';
+                    result += std::to_string(tm_val.tm_min);
+                    break;
+                }
+                case 'S': {
+                    if (tm_val.tm_sec < 10) result += '0';
+                    result += std::to_string(tm_val.tm_sec);
+                    break;
+                }
+                case 'l': {
+                    result += level_to_string(level);
+                    break;
+                }
+                case 'v': {
+                    result += message;
+                    break;
+                }
+                case '%': {
+                    result += '%';
+                    break;
+                }
+                default: {
+                    result += '%';
+                    result += spec;
+                    break;
+                }
+            }
+        } else {
+            result += format[i];
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Internal logging implementation.
+ */
+inline void log_impl(int level, const std::string& message) {
+    auto& state = get_state();
+    std::lock_guard<std::mutex> lock(state.mutex);
+
+    // Check if message should be logged to console
+    if (level >= state.current_level) {
+        std::string formatted = format_message(level, message, state.format_string);
+        std::ostream& out = (level >= WARN) ? std::cerr : std::cout;
+        out << formatted << std::endl;
+    }
+
+    // Write to file outputs
+    for (auto& fo : state.file_outputs) {
+        if (level >= fo.min_level && fo.file && fo.file->is_open()) {
+            std::string formatted = format_message(level, message, state.format_string);
+            *fo.file << formatted << std::endl;
+            fo.file->flush();
+        }
+    }
+}
+
+/**
+ * Internal logging implementation with key-value pair.
+ */
+inline void log_impl_kv(int level, const std::string& message, const std::string& key, const std::string& value) {
+    std::string full_message = message + " {" + key + ": " + value + "}";
+    log_impl(level, full_message);
+}
+
+/**
+ * Logs a debug-level message.
+ */
+inline void debug(const std::string& message) {
+    log_impl(DEBUG, message);
+}
+
+/**
+ * Logs a debug-level message with a key-value pair.
+ */
+inline void debug_kv(const std::string& message, const std::string& key, const std::string& value) {
+    log_impl_kv(DEBUG, message, key, value);
+}
+
+/**
+ * Logs an info-level message.
+ */
+inline void info(const std::string& message) {
+    log_impl(INFO, message);
+}
+
+/**
+ * Logs an info-level message with a key-value pair.
+ */
+inline void info_kv(const std::string& message, const std::string& key, const std::string& value) {
+    log_impl_kv(INFO, message, key, value);
+}
+
+/**
+ * Logs a warning-level message.
+ */
+inline void warn(const std::string& message) {
+    log_impl(WARN, message);
+}
+
+/**
+ * Logs a warning-level message with a key-value pair.
+ */
+inline void warn_kv(const std::string& message, const std::string& key, const std::string& value) {
+    log_impl_kv(WARN, message, key, value);
+}
+
+/**
+ * Logs an error-level message.
+ */
+inline void error(const std::string& message) {
+    log_impl(ERROR, message);
+}
+
+/**
+ * Logs an error-level message with a key-value pair.
+ */
+inline void error_kv(const std::string& message, const std::string& key, const std::string& value) {
+    log_impl_kv(ERROR, message, key, value);
+}
+
+/**
+ * Sets the minimum logging level for console output.
+ * Messages below this level will be suppressed.
+ */
+inline void set_level(int level) {
+    auto& state = get_state();
+    std::lock_guard<std::mutex> lock(state.mutex);
+    state.current_level = level;
+}
+
+/**
+ * Sets the log output format.
+ *
+ * Supported format specifiers:
+ * - %Y - 4-digit year
+ * - %m - 2-digit month (01-12)
+ * - %d - 2-digit day (01-31)
+ * - %H - 2-digit hour (00-23)
+ * - %M - 2-digit minute (00-59)
+ * - %S - 2-digit second (00-59)
+ * - %l - log level name
+ * - %v - the log message
+ * - %% - literal percent sign
+ */
+inline void set_format(const std::string& format) {
+    auto& state = get_state();
+    std::lock_guard<std::mutex> lock(state.mutex);
+    state.format_string = format;
+}
+
+/**
+ * Adds a file as a logging output destination.
+ * All log messages at or above the current level will be written to this file.
+ */
+inline void add_file(const std::string& path) {
+    auto& state = get_state();
+    std::lock_guard<std::mutex> lock(state.mutex);
+
+    LogState::FileOutput fo;
+    fo.file = std::make_unique<std::ofstream>(path, std::ios::app);
+    fo.min_level = state.current_level;
+    state.file_outputs.push_back(std::move(fo));
+}
+
+/**
+ * Adds a file as a logging output destination with a specific minimum level.
+ * Only messages at or above the specified level will be written to this file.
+ */
+inline void add_file_level(const std::string& path, int level) {
+    auto& state = get_state();
+    std::lock_guard<std::mutex> lock(state.mutex);
+
+    LogState::FileOutput fo;
+    fo.file = std::make_unique<std::ofstream>(path, std::ios::app);
+    fo.min_level = level;
+    state.file_outputs.push_back(std::move(fo));
+}
+
+}  // namespace log

--- a/runtime/sync/sync.hpp
+++ b/runtime/sync/sync.hpp
@@ -1,0 +1,209 @@
+/**
+ * @file sync.hpp
+ * @brief Bishop synchronization runtime library.
+ *
+ * Provides synchronization primitives for Bishop programs.
+ * This header is included when programs import the sync module.
+ */
+
+#pragma once
+
+#include <mutex>
+#include <atomic>
+#include <condition_variable>
+#include <memory>
+#include <functional>
+
+namespace bsync {
+
+// ============================================================================
+// Mutex - Mutual exclusion lock
+// ============================================================================
+
+/**
+ * Mutex wrapper for Bishop.
+ * Uses shared_ptr to allow copying in Bishop's value semantics.
+ */
+struct Mutex {
+    std::shared_ptr<std::mutex> impl;
+
+    Mutex() : impl(std::make_shared<std::mutex>()) {}
+};
+
+/**
+ * Creates a new mutex.
+ */
+inline Mutex mutex_create() {
+    return Mutex();
+}
+
+/**
+ * Acquires the mutex lock. Blocks until available.
+ */
+inline void mutex_lock(Mutex& mtx) {
+    mtx.impl->lock();
+}
+
+/**
+ * Releases the mutex lock.
+ */
+inline void mutex_unlock(Mutex& mtx) {
+    mtx.impl->unlock();
+}
+
+/**
+ * Attempts to acquire the lock without blocking.
+ * Returns true if lock was acquired, false otherwise.
+ */
+inline bool mutex_try_lock(Mutex& mtx) {
+    return mtx.impl->try_lock();
+}
+
+// ============================================================================
+// WaitGroup - Coordinate completion of goroutines
+// ============================================================================
+
+/**
+ * WaitGroup implementation for Bishop.
+ * Uses shared_ptr to allow copying in Bishop's value semantics.
+ */
+struct WaitGroup {
+    struct Impl {
+        std::mutex mtx;
+        std::condition_variable cv;
+        int counter = 0;
+    };
+
+    std::shared_ptr<Impl> impl;
+
+    WaitGroup() : impl(std::make_shared<Impl>()) {}
+};
+
+/**
+ * Creates a new WaitGroup.
+ */
+inline WaitGroup waitgroup_create() {
+    return WaitGroup();
+}
+
+/**
+ * Adds delta to the WaitGroup counter.
+ */
+inline void waitgroup_add(WaitGroup& wg, int64_t n) {
+    std::lock_guard<std::mutex> lock(wg.impl->mtx);
+    wg.impl->counter += static_cast<int>(n);
+}
+
+/**
+ * Decrements the WaitGroup counter by 1.
+ * Wakes waiting goroutines when counter reaches zero.
+ */
+inline void waitgroup_done(WaitGroup& wg) {
+    std::unique_lock<std::mutex> lock(wg.impl->mtx);
+    wg.impl->counter--;
+
+    if (wg.impl->counter <= 0) {
+        lock.unlock();
+        wg.impl->cv.notify_all();
+    }
+}
+
+/**
+ * Blocks until the WaitGroup counter reaches zero.
+ */
+inline void waitgroup_wait(WaitGroup& wg) {
+    std::unique_lock<std::mutex> lock(wg.impl->mtx);
+    wg.impl->cv.wait(lock, [&wg]() { return wg.impl->counter <= 0; });
+}
+
+// ============================================================================
+// Once - Execute exactly once
+// ============================================================================
+
+/**
+ * Once implementation for Bishop.
+ * Uses shared_ptr to allow copying in Bishop's value semantics.
+ */
+struct Once {
+    struct Impl {
+        std::once_flag flag;
+    };
+
+    std::shared_ptr<Impl> impl;
+
+    Once() : impl(std::make_shared<Impl>()) {}
+};
+
+/**
+ * Creates a new Once object.
+ */
+inline Once once_create() {
+    return Once();
+}
+
+/**
+ * Executes the function exactly once, even if called concurrently.
+ */
+inline void once_do(Once& once, std::function<void()> f) {
+    std::call_once(once.impl->flag, f);
+}
+
+// ============================================================================
+// AtomicInt - Lock-free atomic integer
+// ============================================================================
+
+/**
+ * AtomicInt implementation for Bishop.
+ * Uses shared_ptr to allow copying in Bishop's value semantics.
+ */
+struct AtomicInt {
+    std::shared_ptr<std::atomic<int64_t>> impl;
+
+    AtomicInt() : impl(std::make_shared<std::atomic<int64_t>>(0)) {}
+    explicit AtomicInt(int64_t initial) : impl(std::make_shared<std::atomic<int64_t>>(initial)) {}
+};
+
+/**
+ * Creates a new atomic integer with the given initial value.
+ */
+inline AtomicInt atomic_int_create(int64_t initial) {
+    return AtomicInt(initial);
+}
+
+/**
+ * Atomically loads and returns the current value.
+ */
+inline int64_t atomic_int_load(AtomicInt& a) {
+    return a.impl->load(std::memory_order_seq_cst);
+}
+
+/**
+ * Atomically stores a new value.
+ */
+inline void atomic_int_store(AtomicInt& a, int64_t val) {
+    a.impl->store(val, std::memory_order_seq_cst);
+}
+
+/**
+ * Atomically adds delta and returns the previous value.
+ */
+inline int64_t atomic_int_add(AtomicInt& a, int64_t delta) {
+    return a.impl->fetch_add(delta, std::memory_order_seq_cst);
+}
+
+/**
+ * Atomically swaps the value and returns the old value.
+ */
+inline int64_t atomic_int_swap(AtomicInt& a, int64_t val) {
+    return a.impl->exchange(val, std::memory_order_seq_cst);
+}
+
+/**
+ * Atomically compares and swaps if equal.
+ * Returns true if swap occurred, false otherwise.
+ */
+inline bool atomic_int_compare_swap(AtomicInt& a, int64_t expected, int64_t desired) {
+    return a.impl->compare_exchange_strong(expected, desired, std::memory_order_seq_cst);
+}
+
+}  // namespace bsync

--- a/stdlib/http.cpp
+++ b/stdlib/http.cpp
@@ -125,7 +125,7 @@ namespace nog::stdlib {
 /**
  * List of built-in stdlib modules.
  */
-const vector<string> BUILTIN_MODULES = {"http", "fs", "crypto", "net", "process", "regex", "time", "math", "random"};
+const vector<string> BUILTIN_MODULES = {"http", "fs", "crypto", "net", "process", "regex", "time", "math", "random", "log", "sync", "json"};
 
 /**
  * Checks if a module name is a built-in stdlib module.

--- a/stdlib/json.cpp
+++ b/stdlib/json.cpp
@@ -1,0 +1,821 @@
+/**
+ * @file json.cpp
+ * @brief Built-in json module implementation.
+ *
+ * Creates the AST definitions for the json module.
+ * The actual runtime is in src/runtime/json/json.hpp and included as a header.
+ */
+
+/**
+ * @nog_fn parse
+ * @module json
+ * @description Parses a JSON string into a Json value.
+ * @param text str - The JSON string to parse
+ * @returns Json - Parsed JSON value
+ * @errors ParseError - If the JSON is malformed
+ * @example
+ * import json;
+ * data := json.parse('{"name": "Alice", "age": 30}') or return;
+ */
+
+/**
+ * @nog_fn object
+ * @module json
+ * @description Creates an empty JSON object.
+ * @returns Json - An empty JSON object {}
+ * @example
+ * import json;
+ * obj := json.object();
+ * obj.set("name", "Bob");
+ */
+
+/**
+ * @nog_fn array
+ * @module json
+ * @description Creates an empty JSON array.
+ * @returns Json - An empty JSON array []
+ * @example
+ * import json;
+ * arr := json.array();
+ * arr.push(42);
+ */
+
+/**
+ * @nog_fn stringify
+ * @module json
+ * @description Converts a Json value to a JSON string.
+ * @param value Json - The JSON value to serialize
+ * @returns str - JSON string representation
+ * @example
+ * import json;
+ * text := json.stringify(data);
+ */
+
+/**
+ * @nog_fn stringify_pretty
+ * @module json
+ * @description Converts a Json value to a pretty-printed JSON string.
+ * @param value Json - The JSON value to serialize
+ * @returns str - Pretty-printed JSON string
+ * @example
+ * import json;
+ * text := json.stringify_pretty(data);
+ */
+
+/**
+ * @nog_method get
+ * @type Json
+ * @description Gets a value by key (for objects) or index (for arrays).
+ * @param key str - Key name or integer index as string
+ * @returns Json - The value at the given key/index
+ * @errors KeyError - If key does not exist
+ * @example
+ * name := data.get("name") or return;
+ */
+
+/**
+ * @nog_method get_str
+ * @type Json
+ * @description Gets a string value by key.
+ * @param key str - Key name
+ * @returns str - The string value
+ * @errors TypeError - If value is not a string
+ * @errors KeyError - If key does not exist
+ * @example
+ * name := data.get_str("name") or return;
+ */
+
+/**
+ * @nog_method get_int
+ * @type Json
+ * @description Gets an integer value by key.
+ * @param key str - Key name
+ * @returns int - The integer value
+ * @errors TypeError - If value is not a number
+ * @errors KeyError - If key does not exist
+ * @example
+ * age := data.get_int("age") or return;
+ */
+
+/**
+ * @nog_method get_float
+ * @type Json
+ * @description Gets a float value by key.
+ * @param key str - Key name
+ * @returns float - The float value
+ * @errors TypeError - If value is not a number
+ * @errors KeyError - If key does not exist
+ * @example
+ * price := data.get_float("price") or return;
+ */
+
+/**
+ * @nog_method get_bool
+ * @type Json
+ * @description Gets a boolean value by key.
+ * @param key str - Key name
+ * @returns bool - The boolean value
+ * @errors TypeError - If value is not a boolean
+ * @errors KeyError - If key does not exist
+ * @example
+ * active := data.get_bool("active") or return;
+ */
+
+/**
+ * @nog_method get_list
+ * @type Json
+ * @description Gets an array value by key.
+ * @param key str - Key name
+ * @returns Json - The array value
+ * @errors TypeError - If value is not an array
+ * @errors KeyError - If key does not exist
+ * @example
+ * items := data.get_list("items") or return;
+ */
+
+/**
+ * @nog_method get_object
+ * @type Json
+ * @description Gets an object value by key.
+ * @param key str - Key name
+ * @returns Json - The object value
+ * @errors TypeError - If value is not an object
+ * @errors KeyError - If key does not exist
+ * @example
+ * config := data.get_object("config") or return;
+ */
+
+/**
+ * @nog_method path
+ * @type Json
+ * @description Accesses nested values using dot notation path.
+ * @param path str - Dot-separated path (e.g., "user.address.city")
+ * @returns Json - The value at the path
+ * @errors KeyError - If path does not exist
+ * @example
+ * city := data.path("user.address.city") or return;
+ */
+
+/**
+ * @nog_method is_null
+ * @type Json
+ * @description Checks if the JSON value is null.
+ * @returns bool - True if null
+ * @example
+ * if data.is_null() { print("Value is null"); }
+ */
+
+/**
+ * @nog_method is_str
+ * @type Json
+ * @description Checks if the JSON value is a string.
+ * @returns bool - True if string
+ * @example
+ * if data.is_str() { name := data.as_str(); }
+ */
+
+/**
+ * @nog_method is_int
+ * @type Json
+ * @description Checks if the JSON value is an integer.
+ * @returns bool - True if integer
+ * @example
+ * if data.is_int() { count := data.as_int(); }
+ */
+
+/**
+ * @nog_method is_float
+ * @type Json
+ * @description Checks if the JSON value is a float.
+ * @returns bool - True if float
+ * @example
+ * if data.is_float() { value := data.as_float(); }
+ */
+
+/**
+ * @nog_method is_bool
+ * @type Json
+ * @description Checks if the JSON value is a boolean.
+ * @returns bool - True if boolean
+ * @example
+ * if data.is_bool() { flag := data.as_bool(); }
+ */
+
+/**
+ * @nog_method is_list
+ * @type Json
+ * @description Checks if the JSON value is an array.
+ * @returns bool - True if array
+ * @example
+ * if data.is_list() { items := data.as_list(); }
+ */
+
+/**
+ * @nog_method is_object
+ * @type Json
+ * @description Checks if the JSON value is an object.
+ * @returns bool - True if object
+ * @example
+ * if data.is_object() { keys := data.keys(); }
+ */
+
+/**
+ * @nog_method as_str
+ * @type Json
+ * @description Converts the JSON value to a string.
+ * @returns str - The string value
+ * @errors TypeError - If value is not a string
+ * @example
+ * name := data.as_str() or return;
+ */
+
+/**
+ * @nog_method as_int
+ * @type Json
+ * @description Converts the JSON value to an integer.
+ * @returns int - The integer value
+ * @errors TypeError - If value is not a number
+ * @example
+ * count := data.as_int() or return;
+ */
+
+/**
+ * @nog_method as_float
+ * @type Json
+ * @description Converts the JSON value to a float.
+ * @returns float - The float value
+ * @errors TypeError - If value is not a number
+ * @example
+ * price := data.as_float() or return;
+ */
+
+/**
+ * @nog_method as_bool
+ * @type Json
+ * @description Converts the JSON value to a boolean.
+ * @returns bool - The boolean value
+ * @errors TypeError - If value is not a boolean
+ * @example
+ * active := data.as_bool() or return;
+ */
+
+/**
+ * @nog_method set
+ * @type Json
+ * @description Sets a value in a JSON object.
+ * @param key str - The key name
+ * @param value Json - The value to set
+ * @example
+ * obj.set("name", json.parse('"Alice"'));
+ */
+
+/**
+ * @nog_method set_str
+ * @type Json
+ * @description Sets a string value in a JSON object.
+ * @param key str - The key name
+ * @param value str - The string value
+ * @example
+ * obj.set_str("name", "Alice");
+ */
+
+/**
+ * @nog_method set_int
+ * @type Json
+ * @description Sets an integer value in a JSON object.
+ * @param key str - The key name
+ * @param value int - The integer value
+ * @example
+ * obj.set_int("age", 30);
+ */
+
+/**
+ * @nog_method set_float
+ * @type Json
+ * @description Sets a float value in a JSON object.
+ * @param key str - The key name
+ * @param value float - The float value
+ * @example
+ * obj.set_float("price", 19.99);
+ */
+
+/**
+ * @nog_method set_bool
+ * @type Json
+ * @description Sets a boolean value in a JSON object.
+ * @param key str - The key name
+ * @param value bool - The boolean value
+ * @example
+ * obj.set_bool("active", true);
+ */
+
+/**
+ * @nog_method set_null
+ * @type Json
+ * @description Sets a null value in a JSON object.
+ * @param key str - The key name
+ * @example
+ * obj.set_null("optional_field");
+ */
+
+/**
+ * @nog_method push
+ * @type Json
+ * @description Appends a value to a JSON array.
+ * @param value Json - The value to append
+ * @example
+ * arr.push(json.parse("42"));
+ */
+
+/**
+ * @nog_method push_str
+ * @type Json
+ * @description Appends a string to a JSON array.
+ * @param value str - The string to append
+ * @example
+ * arr.push_str("hello");
+ */
+
+/**
+ * @nog_method push_int
+ * @type Json
+ * @description Appends an integer to a JSON array.
+ * @param value int - The integer to append
+ * @example
+ * arr.push_int(42);
+ */
+
+/**
+ * @nog_method push_float
+ * @type Json
+ * @description Appends a float to a JSON array.
+ * @param value float - The float to append
+ * @example
+ * arr.push_float(3.14);
+ */
+
+/**
+ * @nog_method push_bool
+ * @type Json
+ * @description Appends a boolean to a JSON array.
+ * @param value bool - The boolean to append
+ * @example
+ * arr.push_bool(true);
+ */
+
+/**
+ * @nog_method push_null
+ * @type Json
+ * @description Appends a null value to a JSON array.
+ * @example
+ * arr.push_null();
+ */
+
+/**
+ * @nog_method length
+ * @type Json
+ * @description Returns the length of a JSON array or object.
+ * @returns int - Number of elements/keys
+ * @example
+ * count := arr.length();
+ */
+
+/**
+ * @nog_method keys
+ * @type Json
+ * @description Returns the keys of a JSON object as newline-separated string.
+ * @returns str - Newline-separated list of keys
+ * @example
+ * key_list := obj.keys();
+ */
+
+/**
+ * @nog_method has
+ * @type Json
+ * @description Checks if a JSON object has a key.
+ * @param key str - The key to check
+ * @returns bool - True if key exists
+ * @example
+ * if obj.has("name") { ... }
+ */
+
+/**
+ * @nog_method remove
+ * @type Json
+ * @description Removes a key from a JSON object.
+ * @param key str - The key to remove
+ * @example
+ * obj.remove("temp_field");
+ */
+
+#include "json.hpp"
+
+using namespace std;
+
+namespace nog::stdlib {
+
+/**
+ * Creates the AST for the built-in json module.
+ */
+unique_ptr<Program> create_json_module() {
+    auto program = make_unique<Program>();
+
+    // Json :: struct { } (internal state managed in C++)
+    auto json_struct = make_unique<StructDef>();
+    json_struct->name = "Json";
+    json_struct->visibility = Visibility::Public;
+    program->structs.push_back(move(json_struct));
+
+    // fn parse(str text) -> json.Json or err
+    auto parse_fn = make_unique<FunctionDef>();
+    parse_fn->name = "parse";
+    parse_fn->visibility = Visibility::Public;
+    parse_fn->params.push_back({"str", "text"});
+    parse_fn->return_type = "json.Json";
+    parse_fn->error_type = "err";
+    program->functions.push_back(move(parse_fn));
+
+    // fn object() -> json.Json
+    auto object_fn = make_unique<FunctionDef>();
+    object_fn->name = "object";
+    object_fn->visibility = Visibility::Public;
+    object_fn->return_type = "json.Json";
+    program->functions.push_back(move(object_fn));
+
+    // fn array() -> json.Json
+    auto array_fn = make_unique<FunctionDef>();
+    array_fn->name = "array";
+    array_fn->visibility = Visibility::Public;
+    array_fn->return_type = "json.Json";
+    program->functions.push_back(move(array_fn));
+
+    // fn stringify(json.Json value) -> str
+    auto stringify_fn = make_unique<FunctionDef>();
+    stringify_fn->name = "stringify";
+    stringify_fn->visibility = Visibility::Public;
+    stringify_fn->params.push_back({"json.Json", "value"});
+    stringify_fn->return_type = "str";
+    program->functions.push_back(move(stringify_fn));
+
+    // fn stringify_pretty(json.Json value) -> str
+    auto stringify_pretty_fn = make_unique<FunctionDef>();
+    stringify_pretty_fn->name = "stringify_pretty";
+    stringify_pretty_fn->visibility = Visibility::Public;
+    stringify_pretty_fn->params.push_back({"json.Json", "value"});
+    stringify_pretty_fn->return_type = "str";
+    program->functions.push_back(move(stringify_pretty_fn));
+
+    // ===== Json Methods =====
+
+    // Json :: is_null(self) -> bool
+    auto is_null_method = make_unique<MethodDef>();
+    is_null_method->struct_name = "Json";
+    is_null_method->name = "is_null";
+    is_null_method->visibility = Visibility::Public;
+    is_null_method->params.push_back({"json.Json", "self"});
+    is_null_method->return_type = "bool";
+    program->methods.push_back(move(is_null_method));
+
+    // Json :: is_str(self) -> bool
+    auto is_str_method = make_unique<MethodDef>();
+    is_str_method->struct_name = "Json";
+    is_str_method->name = "is_str";
+    is_str_method->visibility = Visibility::Public;
+    is_str_method->params.push_back({"json.Json", "self"});
+    is_str_method->return_type = "bool";
+    program->methods.push_back(move(is_str_method));
+
+    // Json :: is_int(self) -> bool
+    auto is_int_method = make_unique<MethodDef>();
+    is_int_method->struct_name = "Json";
+    is_int_method->name = "is_int";
+    is_int_method->visibility = Visibility::Public;
+    is_int_method->params.push_back({"json.Json", "self"});
+    is_int_method->return_type = "bool";
+    program->methods.push_back(move(is_int_method));
+
+    // Json :: is_float(self) -> bool
+    auto is_float_method = make_unique<MethodDef>();
+    is_float_method->struct_name = "Json";
+    is_float_method->name = "is_float";
+    is_float_method->visibility = Visibility::Public;
+    is_float_method->params.push_back({"json.Json", "self"});
+    is_float_method->return_type = "bool";
+    program->methods.push_back(move(is_float_method));
+
+    // Json :: is_bool(self) -> bool
+    auto is_bool_method = make_unique<MethodDef>();
+    is_bool_method->struct_name = "Json";
+    is_bool_method->name = "is_bool";
+    is_bool_method->visibility = Visibility::Public;
+    is_bool_method->params.push_back({"json.Json", "self"});
+    is_bool_method->return_type = "bool";
+    program->methods.push_back(move(is_bool_method));
+
+    // Json :: is_list(self) -> bool
+    auto is_list_method = make_unique<MethodDef>();
+    is_list_method->struct_name = "Json";
+    is_list_method->name = "is_list";
+    is_list_method->visibility = Visibility::Public;
+    is_list_method->params.push_back({"json.Json", "self"});
+    is_list_method->return_type = "bool";
+    program->methods.push_back(move(is_list_method));
+
+    // Json :: is_object(self) -> bool
+    auto is_object_method = make_unique<MethodDef>();
+    is_object_method->struct_name = "Json";
+    is_object_method->name = "is_object";
+    is_object_method->visibility = Visibility::Public;
+    is_object_method->params.push_back({"json.Json", "self"});
+    is_object_method->return_type = "bool";
+    program->methods.push_back(move(is_object_method));
+
+    // Json :: as_str(self) -> str or err
+    auto as_str_method = make_unique<MethodDef>();
+    as_str_method->struct_name = "Json";
+    as_str_method->name = "as_str";
+    as_str_method->visibility = Visibility::Public;
+    as_str_method->params.push_back({"json.Json", "self"});
+    as_str_method->return_type = "str";
+    as_str_method->error_type = "err";
+    program->methods.push_back(move(as_str_method));
+
+    // Json :: as_int(self) -> int or err
+    auto as_int_method = make_unique<MethodDef>();
+    as_int_method->struct_name = "Json";
+    as_int_method->name = "as_int";
+    as_int_method->visibility = Visibility::Public;
+    as_int_method->params.push_back({"json.Json", "self"});
+    as_int_method->return_type = "int";
+    as_int_method->error_type = "err";
+    program->methods.push_back(move(as_int_method));
+
+    // Json :: as_float(self) -> f64 or err
+    auto as_float_method = make_unique<MethodDef>();
+    as_float_method->struct_name = "Json";
+    as_float_method->name = "as_float";
+    as_float_method->visibility = Visibility::Public;
+    as_float_method->params.push_back({"json.Json", "self"});
+    as_float_method->return_type = "f64";
+    as_float_method->error_type = "err";
+    program->methods.push_back(move(as_float_method));
+
+    // Json :: as_bool(self) -> bool or err
+    auto as_bool_method = make_unique<MethodDef>();
+    as_bool_method->struct_name = "Json";
+    as_bool_method->name = "as_bool";
+    as_bool_method->visibility = Visibility::Public;
+    as_bool_method->params.push_back({"json.Json", "self"});
+    as_bool_method->return_type = "bool";
+    as_bool_method->error_type = "err";
+    program->methods.push_back(move(as_bool_method));
+
+    // Json :: get(self, str key) -> json.Json or err
+    auto get_method = make_unique<MethodDef>();
+    get_method->struct_name = "Json";
+    get_method->name = "get";
+    get_method->visibility = Visibility::Public;
+    get_method->params.push_back({"json.Json", "self"});
+    get_method->params.push_back({"str", "key"});
+    get_method->return_type = "json.Json";
+    get_method->error_type = "err";
+    program->methods.push_back(move(get_method));
+
+    // Json :: get_str(self, str key) -> str or err
+    auto get_str_method = make_unique<MethodDef>();
+    get_str_method->struct_name = "Json";
+    get_str_method->name = "get_str";
+    get_str_method->visibility = Visibility::Public;
+    get_str_method->params.push_back({"json.Json", "self"});
+    get_str_method->params.push_back({"str", "key"});
+    get_str_method->return_type = "str";
+    get_str_method->error_type = "err";
+    program->methods.push_back(move(get_str_method));
+
+    // Json :: get_int(self, str key) -> int or err
+    auto get_int_method = make_unique<MethodDef>();
+    get_int_method->struct_name = "Json";
+    get_int_method->name = "get_int";
+    get_int_method->visibility = Visibility::Public;
+    get_int_method->params.push_back({"json.Json", "self"});
+    get_int_method->params.push_back({"str", "key"});
+    get_int_method->return_type = "int";
+    get_int_method->error_type = "err";
+    program->methods.push_back(move(get_int_method));
+
+    // Json :: get_float(self, str key) -> f64 or err
+    auto get_float_method = make_unique<MethodDef>();
+    get_float_method->struct_name = "Json";
+    get_float_method->name = "get_float";
+    get_float_method->visibility = Visibility::Public;
+    get_float_method->params.push_back({"json.Json", "self"});
+    get_float_method->params.push_back({"str", "key"});
+    get_float_method->return_type = "f64";
+    get_float_method->error_type = "err";
+    program->methods.push_back(move(get_float_method));
+
+    // Json :: get_bool(self, str key) -> bool or err
+    auto get_bool_method = make_unique<MethodDef>();
+    get_bool_method->struct_name = "Json";
+    get_bool_method->name = "get_bool";
+    get_bool_method->visibility = Visibility::Public;
+    get_bool_method->params.push_back({"json.Json", "self"});
+    get_bool_method->params.push_back({"str", "key"});
+    get_bool_method->return_type = "bool";
+    get_bool_method->error_type = "err";
+    program->methods.push_back(move(get_bool_method));
+
+    // Json :: get_list(self, str key) -> json.Json or err
+    auto get_list_method = make_unique<MethodDef>();
+    get_list_method->struct_name = "Json";
+    get_list_method->name = "get_list";
+    get_list_method->visibility = Visibility::Public;
+    get_list_method->params.push_back({"json.Json", "self"});
+    get_list_method->params.push_back({"str", "key"});
+    get_list_method->return_type = "json.Json";
+    get_list_method->error_type = "err";
+    program->methods.push_back(move(get_list_method));
+
+    // Json :: get_object(self, str key) -> json.Json or err
+    auto get_object_method = make_unique<MethodDef>();
+    get_object_method->struct_name = "Json";
+    get_object_method->name = "get_object";
+    get_object_method->visibility = Visibility::Public;
+    get_object_method->params.push_back({"json.Json", "self"});
+    get_object_method->params.push_back({"str", "key"});
+    get_object_method->return_type = "json.Json";
+    get_object_method->error_type = "err";
+    program->methods.push_back(move(get_object_method));
+
+    // Json :: path(self, str path) -> json.Json or err
+    auto path_method = make_unique<MethodDef>();
+    path_method->struct_name = "Json";
+    path_method->name = "path";
+    path_method->visibility = Visibility::Public;
+    path_method->params.push_back({"json.Json", "self"});
+    path_method->params.push_back({"str", "path"});
+    path_method->return_type = "json.Json";
+    path_method->error_type = "err";
+    program->methods.push_back(move(path_method));
+
+    // Json :: set(self, str key, json.Json value)
+    auto set_method = make_unique<MethodDef>();
+    set_method->struct_name = "Json";
+    set_method->name = "set";
+    set_method->visibility = Visibility::Public;
+    set_method->params.push_back({"json.Json", "self"});
+    set_method->params.push_back({"str", "key"});
+    set_method->params.push_back({"json.Json", "value"});
+    program->methods.push_back(move(set_method));
+
+    // Json :: set_str(self, str key, str value)
+    auto set_str_method = make_unique<MethodDef>();
+    set_str_method->struct_name = "Json";
+    set_str_method->name = "set_str";
+    set_str_method->visibility = Visibility::Public;
+    set_str_method->params.push_back({"json.Json", "self"});
+    set_str_method->params.push_back({"str", "key"});
+    set_str_method->params.push_back({"str", "value"});
+    program->methods.push_back(move(set_str_method));
+
+    // Json :: set_int(self, str key, int value)
+    auto set_int_method = make_unique<MethodDef>();
+    set_int_method->struct_name = "Json";
+    set_int_method->name = "set_int";
+    set_int_method->visibility = Visibility::Public;
+    set_int_method->params.push_back({"json.Json", "self"});
+    set_int_method->params.push_back({"str", "key"});
+    set_int_method->params.push_back({"int", "value"});
+    program->methods.push_back(move(set_int_method));
+
+    // Json :: set_float(self, str key, f64 value)
+    auto set_float_method = make_unique<MethodDef>();
+    set_float_method->struct_name = "Json";
+    set_float_method->name = "set_float";
+    set_float_method->visibility = Visibility::Public;
+    set_float_method->params.push_back({"json.Json", "self"});
+    set_float_method->params.push_back({"str", "key"});
+    set_float_method->params.push_back({"f64", "value"});
+    program->methods.push_back(move(set_float_method));
+
+    // Json :: set_bool(self, str key, bool value)
+    auto set_bool_method = make_unique<MethodDef>();
+    set_bool_method->struct_name = "Json";
+    set_bool_method->name = "set_bool";
+    set_bool_method->visibility = Visibility::Public;
+    set_bool_method->params.push_back({"json.Json", "self"});
+    set_bool_method->params.push_back({"str", "key"});
+    set_bool_method->params.push_back({"bool", "value"});
+    program->methods.push_back(move(set_bool_method));
+
+    // Json :: set_null(self, str key)
+    auto set_null_method = make_unique<MethodDef>();
+    set_null_method->struct_name = "Json";
+    set_null_method->name = "set_null";
+    set_null_method->visibility = Visibility::Public;
+    set_null_method->params.push_back({"json.Json", "self"});
+    set_null_method->params.push_back({"str", "key"});
+    program->methods.push_back(move(set_null_method));
+
+    // Json :: push(self, json.Json value)
+    auto push_method = make_unique<MethodDef>();
+    push_method->struct_name = "Json";
+    push_method->name = "push";
+    push_method->visibility = Visibility::Public;
+    push_method->params.push_back({"json.Json", "self"});
+    push_method->params.push_back({"json.Json", "value"});
+    program->methods.push_back(move(push_method));
+
+    // Json :: push_str(self, str value)
+    auto push_str_method = make_unique<MethodDef>();
+    push_str_method->struct_name = "Json";
+    push_str_method->name = "push_str";
+    push_str_method->visibility = Visibility::Public;
+    push_str_method->params.push_back({"json.Json", "self"});
+    push_str_method->params.push_back({"str", "value"});
+    program->methods.push_back(move(push_str_method));
+
+    // Json :: push_int(self, int value)
+    auto push_int_method = make_unique<MethodDef>();
+    push_int_method->struct_name = "Json";
+    push_int_method->name = "push_int";
+    push_int_method->visibility = Visibility::Public;
+    push_int_method->params.push_back({"json.Json", "self"});
+    push_int_method->params.push_back({"int", "value"});
+    program->methods.push_back(move(push_int_method));
+
+    // Json :: push_float(self, f64 value)
+    auto push_float_method = make_unique<MethodDef>();
+    push_float_method->struct_name = "Json";
+    push_float_method->name = "push_float";
+    push_float_method->visibility = Visibility::Public;
+    push_float_method->params.push_back({"json.Json", "self"});
+    push_float_method->params.push_back({"f64", "value"});
+    program->methods.push_back(move(push_float_method));
+
+    // Json :: push_bool(self, bool value)
+    auto push_bool_method = make_unique<MethodDef>();
+    push_bool_method->struct_name = "Json";
+    push_bool_method->name = "push_bool";
+    push_bool_method->visibility = Visibility::Public;
+    push_bool_method->params.push_back({"json.Json", "self"});
+    push_bool_method->params.push_back({"bool", "value"});
+    program->methods.push_back(move(push_bool_method));
+
+    // Json :: push_null(self)
+    auto push_null_method = make_unique<MethodDef>();
+    push_null_method->struct_name = "Json";
+    push_null_method->name = "push_null";
+    push_null_method->visibility = Visibility::Public;
+    push_null_method->params.push_back({"json.Json", "self"});
+    program->methods.push_back(move(push_null_method));
+
+    // Json :: length(self) -> int
+    auto length_method = make_unique<MethodDef>();
+    length_method->struct_name = "Json";
+    length_method->name = "length";
+    length_method->visibility = Visibility::Public;
+    length_method->params.push_back({"json.Json", "self"});
+    length_method->return_type = "int";
+    program->methods.push_back(move(length_method));
+
+    // Json :: keys(self) -> str
+    auto keys_method = make_unique<MethodDef>();
+    keys_method->struct_name = "Json";
+    keys_method->name = "keys";
+    keys_method->visibility = Visibility::Public;
+    keys_method->params.push_back({"json.Json", "self"});
+    keys_method->return_type = "str";
+    program->methods.push_back(move(keys_method));
+
+    // Json :: has(self, str key) -> bool
+    auto has_method = make_unique<MethodDef>();
+    has_method->struct_name = "Json";
+    has_method->name = "has";
+    has_method->visibility = Visibility::Public;
+    has_method->params.push_back({"json.Json", "self"});
+    has_method->params.push_back({"str", "key"});
+    has_method->return_type = "bool";
+    program->methods.push_back(move(has_method));
+
+    // Json :: remove(self, str key)
+    auto remove_method = make_unique<MethodDef>();
+    remove_method->struct_name = "Json";
+    remove_method->name = "remove";
+    remove_method->visibility = Visibility::Public;
+    remove_method->params.push_back({"json.Json", "self"});
+    remove_method->params.push_back({"str", "key"});
+    program->methods.push_back(move(remove_method));
+
+    return program;
+}
+
+/**
+ * Returns empty - json.hpp is included at the top of generated code
+ * for precompiled header support.
+ */
+string generate_json_runtime() {
+    return "";
+}
+
+}  // namespace nog::stdlib

--- a/stdlib/json.hpp
+++ b/stdlib/json.hpp
@@ -1,0 +1,27 @@
+/**
+ * @file json.hpp
+ * @brief Built-in json module header.
+ *
+ * Declares the AST creation functions for the json module.
+ * The actual runtime is in src/runtime/json/json.hpp.
+ */
+
+#pragma once
+
+#include "parser/ast.hpp"
+#include <memory>
+#include <string>
+
+namespace nog::stdlib {
+
+/**
+ * Creates the AST for the built-in json module.
+ */
+std::unique_ptr<Program> create_json_module();
+
+/**
+ * Generates the json runtime code (empty - uses precompiled header).
+ */
+std::string generate_json_runtime();
+
+}  // namespace nog::stdlib

--- a/stdlib/log.cpp
+++ b/stdlib/log.cpp
@@ -1,0 +1,307 @@
+/**
+ * @file log.cpp
+ * @brief Built-in log (logging) module implementation.
+ *
+ * Creates the AST definitions for the log module.
+ * The actual runtime is in src/runtime/log/log.hpp and included as a header.
+ */
+
+/**
+ * @nog_fn debug
+ * @module log
+ * @description Logs a debug-level message.
+ * @param message str - The message to log
+ * @returns void
+ * @example
+ * import log;
+ * log.debug("Entering function foo");
+ */
+
+/**
+ * @nog_fn debug_kv
+ * @module log
+ * @description Logs a debug-level message with a key-value pair.
+ * @param message str - The message to log
+ * @param key str - The key for additional context
+ * @param value str - The value for additional context
+ * @returns void
+ * @example
+ * import log;
+ * log.debug_kv("Processing item", "item_id", "123");
+ */
+
+/**
+ * @nog_fn info
+ * @module log
+ * @description Logs an info-level message.
+ * @param message str - The message to log
+ * @returns void
+ * @example
+ * import log;
+ * log.info("Server started");
+ */
+
+/**
+ * @nog_fn info_kv
+ * @module log
+ * @description Logs an info-level message with a key-value pair.
+ * @param message str - The message to log
+ * @param key str - The key for additional context
+ * @param value str - The value for additional context
+ * @returns void
+ * @example
+ * import log;
+ * log.info_kv("User logged in", "user_id", "12345");
+ */
+
+/**
+ * @nog_fn warn
+ * @module log
+ * @description Logs a warning-level message.
+ * @param message str - The message to log
+ * @returns void
+ * @example
+ * import log;
+ * log.warn("Disk space low");
+ */
+
+/**
+ * @nog_fn warn_kv
+ * @module log
+ * @description Logs a warning-level message with a key-value pair.
+ * @param message str - The message to log
+ * @param key str - The key for additional context
+ * @param value str - The value for additional context
+ * @returns void
+ * @example
+ * import log;
+ * log.warn_kv("High memory usage", "percent", "95");
+ */
+
+/**
+ * @nog_fn error
+ * @module log
+ * @description Logs an error-level message.
+ * @param message str - The message to log
+ * @returns void
+ * @example
+ * import log;
+ * log.error("Failed to connect to database");
+ */
+
+/**
+ * @nog_fn error_kv
+ * @module log
+ * @description Logs an error-level message with a key-value pair.
+ * @param message str - The message to log
+ * @param key str - The key for additional context
+ * @param value str - The value for additional context
+ * @returns void
+ * @example
+ * import log;
+ * log.error_kv("Connection failed", "host", "example.com");
+ */
+
+/**
+ * @nog_fn set_level
+ * @module log
+ * @description Sets the minimum logging level. Messages below this level are suppressed.
+ * @param level int - The log level (log.DEBUG, log.INFO, log.WARN, log.ERROR)
+ * @returns void
+ * @example
+ * import log;
+ * log.set_level(log.INFO);  // Suppress debug messages
+ */
+
+/**
+ * @nog_fn set_format
+ * @module log
+ * @description Sets the log output format using strftime-style specifiers.
+ * @param format str - Format string (e.g., "[%Y-%m-%d %H:%M:%S] [%l] %v")
+ * @returns void
+ * @example
+ * import log;
+ * log.set_format("[%H:%M:%S] %v");
+ */
+
+/**
+ * @nog_fn add_file
+ * @module log
+ * @description Adds a file as a logging output destination.
+ * @param path str - Path to the log file
+ * @returns void
+ * @example
+ * import log;
+ * log.add_file("app.log");
+ */
+
+/**
+ * @nog_fn add_file_level
+ * @module log
+ * @description Adds a file as a logging output with a specific minimum level.
+ * @param path str - Path to the log file
+ * @param level int - Minimum log level for this file
+ * @returns void
+ * @example
+ * import log;
+ * log.add_file_level("errors.log", log.ERROR);
+ */
+
+#include "log.hpp"
+
+using namespace std;
+
+namespace nog::stdlib {
+
+/**
+ * Creates the AST for the built-in log module.
+ */
+unique_ptr<Program> create_log_module() {
+    auto program = make_unique<Program>();
+
+    // Constants for log levels
+    // const int DEBUG = 0
+    auto debug_const = make_unique<VariableDecl>();
+    debug_const->name = "DEBUG";
+    debug_const->type = "int";
+    debug_const->is_const = true;
+    program->constants.push_back(move(debug_const));
+
+    // const int INFO = 1
+    auto info_const = make_unique<VariableDecl>();
+    info_const->name = "INFO";
+    info_const->type = "int";
+    info_const->is_const = true;
+    program->constants.push_back(move(info_const));
+
+    // const int WARN = 2
+    auto warn_const = make_unique<VariableDecl>();
+    warn_const->name = "WARN";
+    warn_const->type = "int";
+    warn_const->is_const = true;
+    program->constants.push_back(move(warn_const));
+
+    // const int ERROR = 3
+    auto error_const = make_unique<VariableDecl>();
+    error_const->name = "ERROR";
+    error_const->type = "int";
+    error_const->is_const = true;
+    program->constants.push_back(move(error_const));
+
+    // fn debug(str message) -> void
+    auto debug_fn = make_unique<FunctionDef>();
+    debug_fn->name = "debug";
+    debug_fn->visibility = Visibility::Public;
+    debug_fn->params.push_back({"str", "message"});
+    debug_fn->return_type = "void";
+    program->functions.push_back(move(debug_fn));
+
+    // fn debug_kv(str message, str key, str value) -> void
+    auto debug_kv_fn = make_unique<FunctionDef>();
+    debug_kv_fn->name = "debug_kv";
+    debug_kv_fn->visibility = Visibility::Public;
+    debug_kv_fn->params.push_back({"str", "message"});
+    debug_kv_fn->params.push_back({"str", "key"});
+    debug_kv_fn->params.push_back({"str", "value"});
+    debug_kv_fn->return_type = "void";
+    program->functions.push_back(move(debug_kv_fn));
+
+    // fn info(str message) -> void
+    auto info_fn = make_unique<FunctionDef>();
+    info_fn->name = "info";
+    info_fn->visibility = Visibility::Public;
+    info_fn->params.push_back({"str", "message"});
+    info_fn->return_type = "void";
+    program->functions.push_back(move(info_fn));
+
+    // fn info_kv(str message, str key, str value) -> void
+    auto info_kv_fn = make_unique<FunctionDef>();
+    info_kv_fn->name = "info_kv";
+    info_kv_fn->visibility = Visibility::Public;
+    info_kv_fn->params.push_back({"str", "message"});
+    info_kv_fn->params.push_back({"str", "key"});
+    info_kv_fn->params.push_back({"str", "value"});
+    info_kv_fn->return_type = "void";
+    program->functions.push_back(move(info_kv_fn));
+
+    // fn warn(str message) -> void
+    auto warn_fn = make_unique<FunctionDef>();
+    warn_fn->name = "warn";
+    warn_fn->visibility = Visibility::Public;
+    warn_fn->params.push_back({"str", "message"});
+    warn_fn->return_type = "void";
+    program->functions.push_back(move(warn_fn));
+
+    // fn warn_kv(str message, str key, str value) -> void
+    auto warn_kv_fn = make_unique<FunctionDef>();
+    warn_kv_fn->name = "warn_kv";
+    warn_kv_fn->visibility = Visibility::Public;
+    warn_kv_fn->params.push_back({"str", "message"});
+    warn_kv_fn->params.push_back({"str", "key"});
+    warn_kv_fn->params.push_back({"str", "value"});
+    warn_kv_fn->return_type = "void";
+    program->functions.push_back(move(warn_kv_fn));
+
+    // fn error(str message) -> void
+    auto error_fn = make_unique<FunctionDef>();
+    error_fn->name = "error";
+    error_fn->visibility = Visibility::Public;
+    error_fn->params.push_back({"str", "message"});
+    error_fn->return_type = "void";
+    program->functions.push_back(move(error_fn));
+
+    // fn error_kv(str message, str key, str value) -> void
+    auto error_kv_fn = make_unique<FunctionDef>();
+    error_kv_fn->name = "error_kv";
+    error_kv_fn->visibility = Visibility::Public;
+    error_kv_fn->params.push_back({"str", "message"});
+    error_kv_fn->params.push_back({"str", "key"});
+    error_kv_fn->params.push_back({"str", "value"});
+    error_kv_fn->return_type = "void";
+    program->functions.push_back(move(error_kv_fn));
+
+    // fn set_level(int level) -> void
+    auto set_level_fn = make_unique<FunctionDef>();
+    set_level_fn->name = "set_level";
+    set_level_fn->visibility = Visibility::Public;
+    set_level_fn->params.push_back({"int", "level"});
+    set_level_fn->return_type = "void";
+    program->functions.push_back(move(set_level_fn));
+
+    // fn set_format(str format) -> void
+    auto set_format_fn = make_unique<FunctionDef>();
+    set_format_fn->name = "set_format";
+    set_format_fn->visibility = Visibility::Public;
+    set_format_fn->params.push_back({"str", "format"});
+    set_format_fn->return_type = "void";
+    program->functions.push_back(move(set_format_fn));
+
+    // fn add_file(str path) -> void
+    auto add_file_fn = make_unique<FunctionDef>();
+    add_file_fn->name = "add_file";
+    add_file_fn->visibility = Visibility::Public;
+    add_file_fn->params.push_back({"str", "path"});
+    add_file_fn->return_type = "void";
+    program->functions.push_back(move(add_file_fn));
+
+    // fn add_file_level(str path, int level) -> void
+    auto add_file_level_fn = make_unique<FunctionDef>();
+    add_file_level_fn->name = "add_file_level";
+    add_file_level_fn->visibility = Visibility::Public;
+    add_file_level_fn->params.push_back({"str", "path"});
+    add_file_level_fn->params.push_back({"int", "level"});
+    add_file_level_fn->return_type = "void";
+    program->functions.push_back(move(add_file_level_fn));
+
+    return program;
+}
+
+/**
+ * Returns empty - log.hpp is included at the top of generated code
+ * for precompiled header support.
+ */
+string generate_log_runtime() {
+    return "";
+}
+
+}  // namespace nog::stdlib

--- a/stdlib/log.hpp
+++ b/stdlib/log.hpp
@@ -1,0 +1,27 @@
+/**
+ * @file log.hpp
+ * @brief Built-in log (logging) module header.
+ *
+ * Declares the AST creation functions for the log module.
+ * The actual runtime is in src/runtime/log/log.hpp.
+ */
+
+#pragma once
+
+#include "parser/ast.hpp"
+#include <memory>
+#include <string>
+
+namespace nog::stdlib {
+
+/**
+ * Creates the AST for the built-in log module.
+ */
+std::unique_ptr<Program> create_log_module();
+
+/**
+ * Generates the log runtime code (empty - uses precompiled header).
+ */
+std::string generate_log_runtime();
+
+}  // namespace nog::stdlib

--- a/stdlib/sync.cpp
+++ b/stdlib/sync.cpp
@@ -1,0 +1,363 @@
+/**
+ * @file sync.cpp
+ * @brief Built-in sync (synchronization) module implementation.
+ *
+ * Creates the AST definitions for the sync module.
+ * The actual runtime is in src/runtime/sync/sync.hpp and included as a header.
+ */
+
+/**
+ * @nog_fn mutex_create
+ * @module sync
+ * @description Creates a new mutex for thread synchronization.
+ * @returns Mutex - A new mutex object
+ * @example
+ * import sync;
+ * mtx := sync.mutex_create();
+ */
+
+/**
+ * @nog_fn mutex_lock
+ * @module sync
+ * @description Acquires the mutex lock. Blocks until lock is available.
+ * @param mtx Mutex - The mutex to lock
+ * @example
+ * import sync;
+ * mtx := sync.mutex_create();
+ * sync.mutex_lock(mtx);
+ * // critical section
+ * sync.mutex_unlock(mtx);
+ */
+
+/**
+ * @nog_fn mutex_unlock
+ * @module sync
+ * @description Releases the mutex lock.
+ * @param mtx Mutex - The mutex to unlock
+ * @example
+ * import sync;
+ * mtx := sync.mutex_create();
+ * sync.mutex_lock(mtx);
+ * // critical section
+ * sync.mutex_unlock(mtx);
+ */
+
+/**
+ * @nog_fn mutex_try_lock
+ * @module sync
+ * @description Attempts to acquire the mutex lock without blocking.
+ * @param mtx Mutex - The mutex to try to lock
+ * @returns bool - True if lock was acquired, false otherwise
+ * @example
+ * import sync;
+ * mtx := sync.mutex_create();
+ * if sync.mutex_try_lock(mtx) {
+ *     // critical section
+ *     sync.mutex_unlock(mtx);
+ * }
+ */
+
+/**
+ * @nog_fn waitgroup_create
+ * @module sync
+ * @description Creates a new WaitGroup for coordinating goroutines.
+ * @returns WaitGroup - A new wait group object
+ * @example
+ * import sync;
+ * wg := sync.waitgroup_create();
+ */
+
+/**
+ * @nog_fn waitgroup_add
+ * @module sync
+ * @description Adds delta to the WaitGroup counter.
+ * @param wg WaitGroup - The wait group
+ * @param n int - The delta to add (usually 1)
+ * @example
+ * import sync;
+ * wg := sync.waitgroup_create();
+ * sync.waitgroup_add(wg, 1);
+ */
+
+/**
+ * @nog_fn waitgroup_done
+ * @module sync
+ * @description Decrements the WaitGroup counter by 1.
+ * @param wg WaitGroup - The wait group
+ * @example
+ * import sync;
+ * wg := sync.waitgroup_create();
+ * sync.waitgroup_add(wg, 1);
+ * // ... do work ...
+ * sync.waitgroup_done(wg);
+ */
+
+/**
+ * @nog_fn waitgroup_wait
+ * @module sync
+ * @description Blocks until the WaitGroup counter reaches zero.
+ * @param wg WaitGroup - The wait group to wait on
+ * @example
+ * import sync;
+ * wg := sync.waitgroup_create();
+ * sync.waitgroup_add(wg, 2);
+ * go worker(wg);
+ * go worker(wg);
+ * sync.waitgroup_wait(wg);
+ */
+
+/**
+ * @nog_fn once_create
+ * @module sync
+ * @description Creates a Once object for one-time initialization.
+ * @returns Once - A new once object
+ * @example
+ * import sync;
+ * once := sync.once_create();
+ */
+
+/**
+ * @nog_fn once_do
+ * @module sync
+ * @description Executes the function exactly once, even if called concurrently.
+ * @param once Once - The once object
+ * @param fn fn() - The function to execute once
+ * @example
+ * import sync;
+ * once := sync.once_create();
+ * sync.once_do(once, init_fn);
+ */
+
+/**
+ * @nog_fn atomic_int_create
+ * @module sync
+ * @description Creates a new atomic integer with initial value.
+ * @param initial int - The initial value
+ * @returns AtomicInt - A new atomic integer
+ * @example
+ * import sync;
+ * counter := sync.atomic_int_create(0);
+ */
+
+/**
+ * @nog_fn atomic_int_load
+ * @module sync
+ * @description Atomically loads and returns the current value.
+ * @param a AtomicInt - The atomic integer
+ * @returns int - The current value
+ * @example
+ * import sync;
+ * counter := sync.atomic_int_create(0);
+ * val := sync.atomic_int_load(counter);
+ */
+
+/**
+ * @nog_fn atomic_int_store
+ * @module sync
+ * @description Atomically stores a new value.
+ * @param a AtomicInt - The atomic integer
+ * @param val int - The value to store
+ * @example
+ * import sync;
+ * counter := sync.atomic_int_create(0);
+ * sync.atomic_int_store(counter, 42);
+ */
+
+/**
+ * @nog_fn atomic_int_add
+ * @module sync
+ * @description Atomically adds delta and returns the previous value.
+ * @param a AtomicInt - The atomic integer
+ * @param delta int - The value to add
+ * @returns int - The previous value before addition
+ * @example
+ * import sync;
+ * counter := sync.atomic_int_create(0);
+ * prev := sync.atomic_int_add(counter, 1);
+ */
+
+/**
+ * @nog_fn atomic_int_swap
+ * @module sync
+ * @description Atomically swaps the value and returns the old value.
+ * @param a AtomicInt - The atomic integer
+ * @param val int - The new value
+ * @returns int - The old value
+ * @example
+ * import sync;
+ * counter := sync.atomic_int_create(0);
+ * old := sync.atomic_int_swap(counter, 100);
+ */
+
+/**
+ * @nog_fn atomic_int_compare_swap
+ * @module sync
+ * @description Atomically compares and swaps if equal.
+ * @param a AtomicInt - The atomic integer
+ * @param expected int - The expected current value
+ * @param desired int - The value to set if current equals expected
+ * @returns bool - True if swap occurred, false otherwise
+ * @example
+ * import sync;
+ * counter := sync.atomic_int_create(0);
+ * success := sync.atomic_int_compare_swap(counter, 0, 1);
+ */
+
+#include "sync.hpp"
+
+using namespace std;
+
+namespace nog::stdlib {
+
+/**
+ * Creates the AST for the built-in sync module.
+ */
+unique_ptr<Program> create_sync_module() {
+    auto program = make_unique<Program>();
+
+    // Mutex functions
+
+    // fn mutex_create() -> Mutex
+    auto mutex_create_fn = make_unique<FunctionDef>();
+    mutex_create_fn->name = "mutex_create";
+    mutex_create_fn->visibility = Visibility::Public;
+    mutex_create_fn->return_type = "Mutex";
+    program->functions.push_back(move(mutex_create_fn));
+
+    // fn mutex_lock(Mutex mtx)
+    auto mutex_lock_fn = make_unique<FunctionDef>();
+    mutex_lock_fn->name = "mutex_lock";
+    mutex_lock_fn->visibility = Visibility::Public;
+    mutex_lock_fn->params.push_back({"Mutex", "mtx"});
+    program->functions.push_back(move(mutex_lock_fn));
+
+    // fn mutex_unlock(Mutex mtx)
+    auto mutex_unlock_fn = make_unique<FunctionDef>();
+    mutex_unlock_fn->name = "mutex_unlock";
+    mutex_unlock_fn->visibility = Visibility::Public;
+    mutex_unlock_fn->params.push_back({"Mutex", "mtx"});
+    program->functions.push_back(move(mutex_unlock_fn));
+
+    // fn mutex_try_lock(Mutex mtx) -> bool
+    auto mutex_try_lock_fn = make_unique<FunctionDef>();
+    mutex_try_lock_fn->name = "mutex_try_lock";
+    mutex_try_lock_fn->visibility = Visibility::Public;
+    mutex_try_lock_fn->params.push_back({"Mutex", "mtx"});
+    mutex_try_lock_fn->return_type = "bool";
+    program->functions.push_back(move(mutex_try_lock_fn));
+
+    // WaitGroup functions
+
+    // fn waitgroup_create() -> WaitGroup
+    auto wg_create_fn = make_unique<FunctionDef>();
+    wg_create_fn->name = "waitgroup_create";
+    wg_create_fn->visibility = Visibility::Public;
+    wg_create_fn->return_type = "WaitGroup";
+    program->functions.push_back(move(wg_create_fn));
+
+    // fn waitgroup_add(WaitGroup wg, int n)
+    auto wg_add_fn = make_unique<FunctionDef>();
+    wg_add_fn->name = "waitgroup_add";
+    wg_add_fn->visibility = Visibility::Public;
+    wg_add_fn->params.push_back({"WaitGroup", "wg"});
+    wg_add_fn->params.push_back({"int", "n"});
+    program->functions.push_back(move(wg_add_fn));
+
+    // fn waitgroup_done(WaitGroup wg)
+    auto wg_done_fn = make_unique<FunctionDef>();
+    wg_done_fn->name = "waitgroup_done";
+    wg_done_fn->visibility = Visibility::Public;
+    wg_done_fn->params.push_back({"WaitGroup", "wg"});
+    program->functions.push_back(move(wg_done_fn));
+
+    // fn waitgroup_wait(WaitGroup wg)
+    auto wg_wait_fn = make_unique<FunctionDef>();
+    wg_wait_fn->name = "waitgroup_wait";
+    wg_wait_fn->visibility = Visibility::Public;
+    wg_wait_fn->params.push_back({"WaitGroup", "wg"});
+    program->functions.push_back(move(wg_wait_fn));
+
+    // Once functions
+
+    // fn once_create() -> Once
+    auto once_create_fn = make_unique<FunctionDef>();
+    once_create_fn->name = "once_create";
+    once_create_fn->visibility = Visibility::Public;
+    once_create_fn->return_type = "Once";
+    program->functions.push_back(move(once_create_fn));
+
+    // fn once_do(Once once, fn() f)
+    auto once_do_fn = make_unique<FunctionDef>();
+    once_do_fn->name = "once_do";
+    once_do_fn->visibility = Visibility::Public;
+    once_do_fn->params.push_back({"Once", "once"});
+    once_do_fn->params.push_back({"fn()", "f"});
+    program->functions.push_back(move(once_do_fn));
+
+    // Atomic integer functions
+
+    // fn atomic_int_create(int initial) -> AtomicInt
+    auto atomic_create_fn = make_unique<FunctionDef>();
+    atomic_create_fn->name = "atomic_int_create";
+    atomic_create_fn->visibility = Visibility::Public;
+    atomic_create_fn->params.push_back({"int", "initial"});
+    atomic_create_fn->return_type = "AtomicInt";
+    program->functions.push_back(move(atomic_create_fn));
+
+    // fn atomic_int_load(AtomicInt a) -> int
+    auto atomic_load_fn = make_unique<FunctionDef>();
+    atomic_load_fn->name = "atomic_int_load";
+    atomic_load_fn->visibility = Visibility::Public;
+    atomic_load_fn->params.push_back({"AtomicInt", "a"});
+    atomic_load_fn->return_type = "int";
+    program->functions.push_back(move(atomic_load_fn));
+
+    // fn atomic_int_store(AtomicInt a, int val)
+    auto atomic_store_fn = make_unique<FunctionDef>();
+    atomic_store_fn->name = "atomic_int_store";
+    atomic_store_fn->visibility = Visibility::Public;
+    atomic_store_fn->params.push_back({"AtomicInt", "a"});
+    atomic_store_fn->params.push_back({"int", "val"});
+    program->functions.push_back(move(atomic_store_fn));
+
+    // fn atomic_int_add(AtomicInt a, int delta) -> int
+    auto atomic_add_fn = make_unique<FunctionDef>();
+    atomic_add_fn->name = "atomic_int_add";
+    atomic_add_fn->visibility = Visibility::Public;
+    atomic_add_fn->params.push_back({"AtomicInt", "a"});
+    atomic_add_fn->params.push_back({"int", "delta"});
+    atomic_add_fn->return_type = "int";
+    program->functions.push_back(move(atomic_add_fn));
+
+    // fn atomic_int_swap(AtomicInt a, int val) -> int
+    auto atomic_swap_fn = make_unique<FunctionDef>();
+    atomic_swap_fn->name = "atomic_int_swap";
+    atomic_swap_fn->visibility = Visibility::Public;
+    atomic_swap_fn->params.push_back({"AtomicInt", "a"});
+    atomic_swap_fn->params.push_back({"int", "val"});
+    atomic_swap_fn->return_type = "int";
+    program->functions.push_back(move(atomic_swap_fn));
+
+    // fn atomic_int_compare_swap(AtomicInt a, int expected, int desired) -> bool
+    auto atomic_cas_fn = make_unique<FunctionDef>();
+    atomic_cas_fn->name = "atomic_int_compare_swap";
+    atomic_cas_fn->visibility = Visibility::Public;
+    atomic_cas_fn->params.push_back({"AtomicInt", "a"});
+    atomic_cas_fn->params.push_back({"int", "expected"});
+    atomic_cas_fn->params.push_back({"int", "desired"});
+    atomic_cas_fn->return_type = "bool";
+    program->functions.push_back(move(atomic_cas_fn));
+
+    return program;
+}
+
+/**
+ * Returns empty - sync.hpp is included at the top of generated code.
+ * The code generator maps "sync" module calls to "bsync::" namespace
+ * to avoid conflict with POSIX sync() function.
+ */
+string generate_sync_runtime() {
+    return "";
+}
+
+}  // namespace nog::stdlib

--- a/stdlib/sync.hpp
+++ b/stdlib/sync.hpp
@@ -1,0 +1,27 @@
+/**
+ * @file sync.hpp
+ * @brief Built-in sync (synchronization) module header.
+ *
+ * Declares the AST creation functions for the sync module.
+ * The actual runtime is in src/runtime/sync/sync.hpp.
+ */
+
+#pragma once
+
+#include "parser/ast.hpp"
+#include <memory>
+#include <string>
+
+namespace nog::stdlib {
+
+/**
+ * Creates the AST for the built-in sync module.
+ */
+std::unique_ptr<Program> create_sync_module();
+
+/**
+ * Generates the sync runtime code (empty - uses precompiled header).
+ */
+std::string generate_sync_runtime();
+
+}  // namespace nog::stdlib

--- a/tests/test_json.b
+++ b/tests/test_json.b
@@ -1,0 +1,251 @@
+// Tests for the json module
+
+import json;
+
+fn test_parse_object() {
+    data := json.parse('{"name": "Alice", "age": 30}') or return;
+    assert_eq(true, data.is_object());
+}
+
+fn test_parse_array() {
+    data := json.parse('[1, 2, 3]') or return;
+    assert_eq(true, data.is_list());
+}
+
+fn test_parse_string() {
+    data := json.parse('"hello"') or return;
+    assert_eq(true, data.is_str());
+    name := data.as_str() or return;
+    assert_eq("hello", name);
+}
+
+fn test_parse_int() {
+    data := json.parse('42') or return;
+    assert_eq(true, data.is_int());
+    val := data.as_int() or return;
+    assert_eq(42, val);
+}
+
+fn test_parse_float() {
+    data := json.parse('3.14') or return;
+    assert_eq(true, data.is_float());
+}
+
+fn test_parse_bool_true() {
+    data := json.parse('true') or return;
+    assert_eq(true, data.is_bool());
+    val := data.as_bool() or return;
+    assert_eq(true, val);
+}
+
+fn test_parse_bool_false() {
+    data := json.parse('false') or return;
+    val := data.as_bool() or return;
+    assert_eq(false, val);
+}
+
+fn test_parse_null() {
+    data := json.parse('null') or return;
+    assert_eq(true, data.is_null());
+}
+
+fn test_parse_invalid_json() {
+    // This should fail to parse
+    result := json.parse('{invalid}') or {
+        // Expected error
+        assert_eq(true, true);
+        return;
+    };
+    // Should not reach here
+    assert_eq(true, false);
+}
+
+fn test_get_str() {
+    data := json.parse('{"name": "Bob"}') or return;
+    name := data.get_str("name") or return;
+    assert_eq("Bob", name);
+}
+
+fn test_get_int() {
+    data := json.parse('{"count": 42}') or return;
+    count := data.get_int("count") or return;
+    assert_eq(42, count);
+}
+
+fn test_get_bool() {
+    data := json.parse('{"active": true}') or return;
+    active := data.get_bool("active") or return;
+    assert_eq(true, active);
+}
+
+fn test_get_list() {
+    data := json.parse('{"items": [1, 2, 3]}') or return;
+    items := data.get_list("items") or return;
+    assert_eq(true, items.is_list());
+    assert_eq(3, items.length());
+}
+
+fn test_get_object() {
+    data := json.parse('{"user": {"name": "Charlie"}}') or return;
+    user := data.get_object("user") or return;
+    assert_eq(true, user.is_object());
+    name := user.get_str("name") or return;
+    assert_eq("Charlie", name);
+}
+
+fn test_path_access() {
+    data := json.parse('{"user": {"address": {"city": "NYC"}}}') or return;
+    city := data.path("user.address.city") or return;
+    city_str := city.as_str() or return;
+    assert_eq("NYC", city_str);
+}
+
+fn test_create_object() {
+    obj := json.object();
+    assert_eq(true, obj.is_object());
+    assert_eq(0, obj.length());
+}
+
+fn test_create_array() {
+    arr := json.array();
+    assert_eq(true, arr.is_list());
+    assert_eq(0, arr.length());
+}
+
+fn test_set_values() {
+    obj := json.object();
+    obj.set_str("name", "Dave");
+    obj.set_int("age", 25);
+    obj.set_bool("active", true);
+    obj.set_float("score", 95.5);
+
+    assert_eq(4, obj.length());
+
+    name := obj.get_str("name") or return;
+    assert_eq("Dave", name);
+
+    age := obj.get_int("age") or return;
+    assert_eq(25, age);
+}
+
+fn test_push_values() {
+    arr := json.array();
+    arr.push_int(1);
+    arr.push_int(2);
+    arr.push_str("three");
+
+    assert_eq(3, arr.length());
+}
+
+fn test_has_key() {
+    data := json.parse('{"name": "Eve"}') or return;
+    assert_eq(true, data.has("name"));
+    assert_eq(false, data.has("age"));
+}
+
+fn test_remove_key() {
+    obj := json.object();
+    obj.set_str("temp", "value");
+    assert_eq(true, obj.has("temp"));
+    obj.remove("temp");
+    assert_eq(false, obj.has("temp"));
+}
+
+fn test_keys() {
+    data := json.parse('{"a": 1, "b": 2}') or return;
+    key_list := data.keys();
+    assert_eq(true, key_list.length() > 0);
+}
+
+fn test_stringify_compact() {
+    obj := json.object();
+    obj.set_str("name", "Frank");
+    result := json.stringify(obj);
+    assert_eq(true, result.length() > 0);
+}
+
+fn test_stringify_pretty() {
+    obj := json.object();
+    obj.set_str("name", "Grace");
+    result := json.stringify_pretty(obj);
+    assert_eq(true, result.length() > 0);
+}
+
+fn test_roundtrip() {
+    original := '{"name":"test","value":42}';
+    data := json.parse(original) or return;
+    result := json.stringify(data);
+    // Parse again to verify
+    data2 := json.parse(result) or return;
+    name := data2.get_str("name") or return;
+    assert_eq("test", name);
+}
+
+fn test_nested_object() {
+    json_str := '{"level1": {"level2": {"level3": "deep"}}}';
+    data := json.parse(json_str) or return;
+    l1 := data.get_object("level1") or return;
+    l2 := l1.get_object("level2") or return;
+    l3 := l2.get_str("level3") or return;
+    assert_eq("deep", l3);
+}
+
+fn test_array_of_objects() {
+    json_str := '[{"id": 1}, {"id": 2}]';
+    data := json.parse(json_str) or return;
+    assert_eq(2, data.length());
+    first := data.get("0") or return;
+    id := first.get_int("id") or return;
+    assert_eq(1, id);
+}
+
+fn test_escape_sequences() {
+    json_str := '{"text": "line1\\nline2\\ttab"}';
+    data := json.parse(json_str) or return;
+    text := data.get_str("text") or return;
+    assert_eq(true, text.length() > 0);
+}
+
+fn test_null_value() {
+    data := json.parse('{"value": null}') or return;
+    val := data.get("value") or return;
+    assert_eq(true, val.is_null());
+}
+
+fn test_set_null() {
+    obj := json.object();
+    obj.set_null("empty");
+    val := obj.get("empty") or return;
+    assert_eq(true, val.is_null());
+}
+
+fn test_push_null() {
+    arr := json.array();
+    arr.push_null();
+    assert_eq(1, arr.length());
+    val := arr.get("0") or return;
+    assert_eq(true, val.is_null());
+}
+
+fn test_negative_numbers() {
+    data := json.parse('-42') or return;
+    val := data.as_int() or return;
+    assert_eq(-42, val);
+}
+
+fn test_scientific_notation() {
+    data := json.parse('1.5e10') or return;
+    assert_eq(true, data.is_float());
+}
+
+fn test_empty_object() {
+    data := json.parse('{}') or return;
+    assert_eq(true, data.is_object());
+    assert_eq(0, data.length());
+}
+
+fn test_empty_array() {
+    data := json.parse('[]') or return;
+    assert_eq(true, data.is_list());
+    assert_eq(0, data.length());
+}

--- a/tests/test_log.b
+++ b/tests/test_log.b
@@ -1,0 +1,88 @@
+// Tests for the log module
+
+import log;
+
+fn test_log_debug() {
+    // Should not crash - debug level logging
+    log.debug("Debug message");
+}
+
+fn test_log_info() {
+    // Should not crash - info level logging
+    log.info("Info message");
+}
+
+fn test_log_warn() {
+    // Should not crash - warn level logging
+    log.warn("Warning message");
+}
+
+fn test_log_error() {
+    // Should not crash - error level logging
+    log.error("Error message");
+}
+
+fn test_log_with_values() {
+    // Should not crash - logging with key-value pairs
+    log.info_kv("User logged in", "user_id", "12345");
+    log.debug_kv("Request received", "method", "GET");
+    log.warn_kv("High memory usage", "percent", "95");
+    log.error_kv("Connection failed", "host", "example.com");
+}
+
+fn test_set_level_debug() {
+    // Set level to debug - all messages should be logged
+    log.set_level(log.DEBUG);
+    log.debug("Should appear at DEBUG level");
+    log.info("Should appear at DEBUG level");
+}
+
+fn test_set_level_info() {
+    // Set level to info - debug should be suppressed
+    log.set_level(log.INFO);
+    log.debug("Should be suppressed");
+    log.info("Should appear at INFO level");
+}
+
+fn test_set_level_warn() {
+    // Set level to warn - debug and info should be suppressed
+    log.set_level(log.WARN);
+    log.debug("Should be suppressed");
+    log.info("Should be suppressed");
+    log.warn("Should appear at WARN level");
+}
+
+fn test_set_level_error() {
+    // Set level to error - only errors should appear
+    log.set_level(log.ERROR);
+    log.debug("Should be suppressed");
+    log.info("Should be suppressed");
+    log.warn("Should be suppressed");
+    log.error("Should appear at ERROR level");
+}
+
+fn test_set_format() {
+    // Set custom format string
+    log.set_format("[%Y-%m-%d %H:%M:%S] [%l] %v");
+    log.info("Message with custom format");
+}
+
+fn test_add_file() {
+    // Add file logging output
+    log.add_file("/tmp/bishop_test.log");
+    log.info("This should go to file");
+}
+
+fn test_add_file_with_level() {
+    // Add file logging with specific level
+    log.add_file_level("/tmp/bishop_error.log", log.ERROR);
+    log.info("This should NOT go to error log");
+    log.error("This SHOULD go to error log");
+}
+
+fn test_level_constants() {
+    // Verify level constants exist and have expected ordering
+    assert_eq(true, log.DEBUG < log.INFO);
+    assert_eq(true, log.INFO < log.WARN);
+    assert_eq(true, log.WARN < log.ERROR);
+}

--- a/tests/test_sync.b
+++ b/tests/test_sync.b
@@ -1,0 +1,170 @@
+// Tests for the sync module
+
+import sync;
+
+// ============================================
+// Mutex Tests
+// ============================================
+
+fn test_mutex_create() {
+    mtx := sync.mutex_create();
+}
+
+fn test_mutex_lock_unlock() {
+    mtx := sync.mutex_create();
+    sync.mutex_lock(mtx);
+    sync.mutex_unlock(mtx);
+}
+
+fn test_mutex_try_lock() {
+    mtx := sync.mutex_create();
+
+    // First try_lock should succeed
+    result := sync.mutex_try_lock(mtx);
+    assert_eq(true, result);
+
+    // Unlock for cleanup
+    sync.mutex_unlock(mtx);
+}
+
+fn test_mutex_relock() {
+    mtx := sync.mutex_create();
+
+    // Lock, unlock, lock again
+    sync.mutex_lock(mtx);
+    sync.mutex_unlock(mtx);
+    sync.mutex_lock(mtx);
+    sync.mutex_unlock(mtx);
+}
+
+// ============================================
+// WaitGroup Tests
+// ============================================
+
+fn test_waitgroup_create() {
+    wg := sync.waitgroup_create();
+}
+
+fn test_waitgroup_add_done() {
+    wg := sync.waitgroup_create();
+    sync.waitgroup_add(wg, 1);
+    sync.waitgroup_done(wg);
+}
+
+fn test_waitgroup_multiple() {
+    wg := sync.waitgroup_create();
+    sync.waitgroup_add(wg, 3);
+    sync.waitgroup_done(wg);
+    sync.waitgroup_done(wg);
+    sync.waitgroup_done(wg);
+}
+
+fn test_waitgroup_wait_immediate() {
+    // Wait on an empty wait group should return immediately
+    wg := sync.waitgroup_create();
+    sync.waitgroup_wait(wg);
+}
+
+fn test_waitgroup_add_wait() {
+    wg := sync.waitgroup_create();
+    sync.waitgroup_add(wg, 1);
+    sync.waitgroup_done(wg);
+    sync.waitgroup_wait(wg);
+}
+
+// ============================================
+// Once Tests
+// ============================================
+
+fn test_once_create() {
+    once := sync.once_create();
+}
+
+// ============================================
+// AtomicInt Tests
+// ============================================
+
+fn test_atomic_create() {
+    counter := sync.atomic_int_create(0);
+}
+
+fn test_atomic_create_with_value() {
+    counter := sync.atomic_int_create(42);
+    val := sync.atomic_int_load(counter);
+    assert_eq(42, val);
+}
+
+fn test_atomic_load_store() {
+    counter := sync.atomic_int_create(0);
+    sync.atomic_int_store(counter, 100);
+    val := sync.atomic_int_load(counter);
+    assert_eq(100, val);
+}
+
+fn test_atomic_add() {
+    counter := sync.atomic_int_create(10);
+
+    // add returns the previous value
+    prev := sync.atomic_int_add(counter, 5);
+    assert_eq(10, prev);
+
+    // current value should be 15
+    current := sync.atomic_int_load(counter);
+    assert_eq(15, current);
+}
+
+fn test_atomic_add_negative() {
+    counter := sync.atomic_int_create(100);
+    prev := sync.atomic_int_add(counter, -30);
+    assert_eq(100, prev);
+
+    current := sync.atomic_int_load(counter);
+    assert_eq(70, current);
+}
+
+fn test_atomic_swap() {
+    counter := sync.atomic_int_create(42);
+
+    // swap returns old value
+    old := sync.atomic_int_swap(counter, 100);
+    assert_eq(42, old);
+
+    // current should be new value
+    current := sync.atomic_int_load(counter);
+    assert_eq(100, current);
+}
+
+fn test_atomic_compare_swap_success() {
+    counter := sync.atomic_int_create(10);
+
+    // CAS should succeed when expected matches
+    success := sync.atomic_int_compare_swap(counter, 10, 20);
+    assert_eq(true, success);
+
+    val := sync.atomic_int_load(counter);
+    assert_eq(20, val);
+}
+
+fn test_atomic_compare_swap_fail() {
+    counter := sync.atomic_int_create(10);
+
+    // CAS should fail when expected doesn't match
+    success := sync.atomic_int_compare_swap(counter, 5, 20);
+    assert_eq(false, success);
+
+    // Value should remain unchanged
+    val := sync.atomic_int_load(counter);
+    assert_eq(10, val);
+}
+
+fn test_atomic_increment_pattern() {
+    counter := sync.atomic_int_create(0);
+
+    // Increment by 1 multiple times
+    sync.atomic_int_add(counter, 1);
+    sync.atomic_int_add(counter, 1);
+    sync.atomic_int_add(counter, 1);
+
+    val := sync.atomic_int_load(counter);
+    assert_eq(3, val);
+}

--- a/typechecker/check_method_call.cpp
+++ b/typechecker/check_method_call.cpp
@@ -125,8 +125,9 @@ TypeInfo check_struct_method(TypeCheckerState& state, const MethodCall& mcall, c
         }
     }
 
-    return method->return_type.empty() ? TypeInfo{"void", false, true}
-                                       : TypeInfo{method->return_type, false, false};
+    bool fallible = !method->error_type.empty();
+    return method->return_type.empty() ? TypeInfo{"void", false, true, fallible}
+                                       : TypeInfo{method->return_type, false, false, fallible};
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR implements three new stdlib modules for Bishop:

- **log module** (#49) - Structured logging with levels, formatting, and file output
- **sync module** (#48) - Synchronization primitives (Mutex, WaitGroup, Once, AtomicInt)
- **json module** (#41) - JSON parsing, building, and querying with fallible operations

### Log Module Features
- Log levels: DEBUG, INFO, WARN, ERROR
- Configurable format strings with strftime specifiers
- Console and file output support
- Key-value logging variants (debug_kv, info_kv, warn_kv, error_kv)

### Sync Module Features
- Mutex with lock/unlock/try_lock
- WaitGroup for goroutine-style coordination
- Once for single-execution initialization
- AtomicInt for lock-free integer operations

### JSON Module Features
- Fallible parse() with "or return" error handling
- Type checking (is_null, is_str, is_int, etc.)
- Safe accessors (get_str, get_int, get_float, get_bool)
- JSONPath-style queries with path()
- Builder pattern for constructing JSON

## Bug Fix

Fixed a typechecker bug where method error_type wasn't propagating the fallible flag to TypeInfo, breaking "or return" handlers.

## Technical Notes

- Uses `bsync` namespace in runtime to avoid POSIX sync() conflict
- No function overloading - uses renamed variants (e.g., debug_kv instead of overloaded debug)
- All functions follow Bishop's fallible pattern with error_type for proper "or return" support

## Test Plan

- [x] tests/test_log.b - Log module tests
- [x] tests/test_sync.b - Sync module tests  
- [x] tests/test_json.b - JSON module tests
- [x] All existing tests still pass

Closes #49, closes #48, closes #41