### PR TITLE
Fix default keyword for string and container types

### DIFF
--- a/tests/test_default_string.b
+++ b/tests/test_default_string.b
@@ -1,0 +1,107 @@
+// Tests for default expressions with all falsy types (Issue #105)
+// https://github.com/chrishayen/bishop/issues/105
+
+// ============================================
+// String default - empty string is falsy
+// ============================================
+
+fn get_empty_string() -> str {
+    return "";
+}
+
+fn get_nonempty_string() -> str {
+    return "value";
+}
+
+fn test_empty_string_literal_default() {
+    s := "" default "fallback";
+    assert_eq(s, "fallback");
+}
+
+fn test_nonempty_string_literal_default() {
+    s := "hello" default "fallback";
+    assert_eq(s, "hello");
+}
+
+fn test_function_empty_string_default() {
+    s := get_empty_string() default "fallback";
+    assert_eq(s, "fallback");
+}
+
+fn test_function_nonempty_string_default() {
+    s := get_nonempty_string() default "fallback";
+    assert_eq(s, "value");
+}
+
+fn test_variable_empty_string_default() {
+    x := "";
+    s := x default "fallback";
+    assert_eq(s, "fallback");
+}
+
+fn test_variable_nonempty_string_default() {
+    x := "hello";
+    s := x default "fallback";
+    assert_eq(s, "hello");
+}
+
+fn test_substr_empty_result_default() {
+    s := "hello";
+    result := s.substr(5, 0) default "fallback";
+    assert_eq(result, "fallback");
+}
+
+fn test_substr_nonempty_result_default() {
+    s := "hello";
+    result := s.substr(0, 3) default "fallback";
+    assert_eq(result, "hel");
+}
+
+// ============================================
+// List default - empty list is falsy
+// ============================================
+
+fn get_empty_list() -> List<int> {
+    return List<int>();
+}
+
+fn get_nonempty_list() -> List<int> {
+    return [1, 2, 3];
+}
+
+fn test_empty_list_literal_default() {
+    l := List<int>() default [99];
+    assert_eq(l.length(), 1);
+    assert_eq(l.get(0), 99);
+}
+
+fn test_nonempty_list_literal_default() {
+    l := [1, 2] default [99];
+    assert_eq(l.length(), 2);
+    assert_eq(l.get(0), 1);
+}
+
+fn test_function_empty_list_default() {
+    l := get_empty_list() default [99];
+    assert_eq(l.length(), 1);
+    assert_eq(l.get(0), 99);
+}
+
+fn test_function_nonempty_list_default() {
+    l := get_nonempty_list() default [99];
+    assert_eq(l.length(), 3);
+    assert_eq(l.get(0), 1);
+}
+
+fn test_variable_empty_list_default() {
+    x := List<int>();
+    l := x default [99];
+    assert_eq(l.length(), 1);
+}
+
+fn test_variable_nonempty_list_default() {
+    x := [1, 2, 3];
+    l := x default [99];
+    assert_eq(l.length(), 3);
+}
+

--- a/tests/test_error_handling.b
+++ b/tests/test_error_handling.b
@@ -198,8 +198,6 @@ fn test_default_with_zero_result() or err {
     assert_eq(y, 50);
 }
 
-// Note: string default not supported (C++ strings not valid in boolean context)
-
 fn test_default_with_false_result() or err {
     b := returns_false() or fail err;
     result := b default true;


### PR DESCRIPTION
## Summary

- Fixes the `default` keyword to work with strings, lists, and other container types
- Previously only worked with types implicitly convertible to bool (int, float, bool, optional)
- Adds `bishop::truthy()` template function to properly check falsy values for all types

## Changes

- **runtime/std/std.hpp**: Add `bishop::truthy<T>()` template that uses C++17 `if constexpr` to handle different type categories
- **codegen/emit_or.cpp**: Update `emit_default_expr` to use `bishop::truthy()` with lambda wrapper
- **tests/test_default_string.b**: Add comprehensive tests for string and list default expressions
- **tests/test_error_handling.b**: Remove outdated comment about string default not being supported

## Example

```bishop
// This now works!
name := get_name() default "unknown";
items := get_items() default [default_item];
```

## Test plan

- [x] All 83 existing tests pass
- [x] New tests cover string literals, variables, function returns, and method calls
- [x] New tests cover list literals, variables, and function returns

Fixes #105